### PR TITLE
fix(#12): remove remaining misère references from comments

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -502,7 +502,6 @@ fun GameScreen(
                 }
 
                 // ── Player-assigned bonuses (compact grid) ─────────────────────
-                // Four bonuses remain after removing Misère (not in official rules).
                 // Each row has a label + ⓘ info icon that shows a tooltip explaining
                 // the bonus and its point value.
                 CompactBonusGrid(
@@ -808,9 +807,6 @@ private fun FormLabel(text: String) {
 }
 
 // Compact bonus grid: shows four player-assigned bonuses as a table.
-//
-// Misère and Double Misère have been removed — they are not part of the
-// official French Tarot règlement.
 //
 // Layout:
 //   Row 0 (header):  empty label | Player1 | Player2 | …


### PR DESCRIPTION
## Summary

- Removes two leftover comments in `GameScreen.kt` that still referenced Misère and Double Misère
- The actual misère gameplay code had already been removed in a previous commit; only explanatory comment text remained

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)