### PR TITLE
refactor: Kotlin audit — idioms, compositionLocal, import order

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
@@ -1,6 +1,6 @@
 package fr.mandarine.tarotcounter
 
-import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 
 // ── Locale enum ───────────────────────────────────────────────────────────────
 //
@@ -16,9 +16,12 @@ enum class AppLocale { EN, FR }
 // Usage:  val locale = LocalAppLocale.current
 //         val strings = appStrings(locale)
 //
+// `staticCompositionLocalOf` is used instead of `compositionLocalOf` because locale
+// changes always recompose the entire tree (via CompositionLocalProvider in MainActivity),
+// so the extra per-caller tracking of `compositionLocalOf` would add cost with no benefit.
 // The default value is EN so that Previews and tests that don't set a provider
 // still compile and render correctly.
-val LocalAppLocale = compositionLocalOf { AppLocale.EN }
+val LocalAppLocale = staticCompositionLocalOf { AppLocale.EN }
 
 // ── String bundle ─────────────────────────────────────────────────────────────
 //

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -66,6 +65,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import java.util.UUID
+import kotlinx.coroutines.launch
 
 // GameScreen handles the full round-by-round flow of a Tarot game on a single scrollable page.
 //
@@ -198,7 +198,7 @@ fun GameScreen(
             playerNames  = displayNames,
             roundHistory = roundHistory,
             onBack       = { showFinalScore = false },
-            onNewGame    = { onEndGame() },
+            onNewGame    = onEndGame,
             modifier     = modifier
         )
         return
@@ -608,9 +608,9 @@ fun GameScreen(
                     // The eligible players are the taker and — in 5-player — the partner.
                     val chelemCandidates = buildList {
                         add(currentTaker)
-                        if (displayNames.size == 5 && selectedPartner != null) {
-                            add(selectedPartner!!)
-                        }
+                        // In a 5-player game the partner (if chosen) can also call chelem.
+                        // Using ?.let avoids a force-unwrap while preserving the same logic.
+                        if (displayNames.size == 5) selectedPartner?.let { add(it) }
                     }
                     PlayerChipSelector(
                         label          = strings.chelemPlayerLabel,
@@ -806,6 +806,16 @@ private fun FormLabel(text: String) {
     )
 }
 
+// Holds the display data and state callbacks for one row of the bonus grid.
+// Declared at file scope (not inside the composable) so it is not recreated on
+// every recomposition of CompactBonusGrid.
+private data class BonusRow(
+    val label: String,
+    val tooltip: String,
+    val value: String?,
+    val onSelect: (String?) -> Unit
+)
+
 // Compact bonus grid: shows four player-assigned bonuses as a table.
 //
 // Layout:
@@ -831,12 +841,6 @@ private fun CompactBonusGrid(
     triplePoignee: String?,   onTriplePoignee: (String?) -> Unit
 ) {
     // Zip labels + tooltips + state pairs into one list for the grid loop.
-    data class BonusRow(
-        val label: String,
-        val tooltip: String,
-        val value: String?,
-        val onSelect: (String?) -> Unit
-    )
     val bonuses = listOf(
         BonusRow(bonusLabels[0], bonusTooltips[0], petitAuBout,   onPetit),
         BonusRow(bonusLabels[1], bonusTooltips[1], poignee,        onPoignee),

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameStorage.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameStorage.kt
@@ -122,16 +122,11 @@ class GameStorage(private val context: Context) {
     suspend fun addGame(game: SavedGame) {
         context.dataStore.edit { prefs ->
             val raw = prefs[GAMES_KEY] ?: "[]"
-            val games = runCatching { json.decodeFromString<List<SavedGame>>(raw) }
+            val existing = runCatching { json.decodeFromString<List<SavedGame>>(raw) }
                 .getOrDefault(emptyList())
-                .toMutableList()
-            // Insert the new game at position 0 so the list stays newest-first.
-            games.add(0, game)
-            // Trim to the limit so the file doesn't grow without bound.
-            if (games.size > MAX_SAVED_GAMES) {
-                games.subList(MAX_SAVED_GAMES, games.size).clear()
-            }
-            prefs[GAMES_KEY] = json.encodeToString(games)
+            // Prepend the new game (newest-first) and trim to the allowed limit in one step.
+            val updated = (listOf(game) + existing).take(MAX_SAVED_GAMES)
+            prefs[GAMES_KEY] = json.encodeToString(updated)
         }
     }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -25,7 +26,6 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight


### PR DESCRIPTION
## Summary

Kotlin audit of the full codebase — no logic changes, all fixes are idiomatic/style/performance improvements:

- **`staticCompositionLocalOf`** — `LocalAppLocale` switched from `compositionLocalOf`: locale changes always recompose the entire tree via `CompositionLocalProvider`, so the per-caller tracking of the dynamic variant adds cost with no benefit
- **`BonusRow` at file scope** — the private `data class` was defined inside `CompactBonusGrid`, causing it to be recreated on every recomposition; moved to private file scope
- **`selectedPartner!!` removed** — replaced force-unwrap with idiomatic `?.let { add(it) }` inside `buildList`
- **Unnecessary lambda wrapper** — `onNewGame = { onEndGame() }` simplified to `onNewGame = onEndGame`
- **Functional `addGame`** — mutable list mutation replaced with `(listOf(game) + existing).take(MAX_SAVED_GAMES)`
- **Import order** — `kotlinx.coroutines.launch` and `imePadding` moved into their correct import groups in `GameScreen.kt` and `LandingScreen.kt`

## Test plan
- [x] `./gradlew testDebugUnitTest` — all 24 tasks pass
- [x] `./gradlew lint` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)