### PR TITLE
feat(#19): move Start Game button above name fields for better keyboard UX

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.getBoundsInRoot
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
 import org.junit.Assert.assertEquals
@@ -122,6 +123,28 @@ class LandingScreenTest {
     fun start_game_button_is_displayed() {
         launch()
         composeTestRule.onNodeWithText("Start Game").assertIsDisplayed()
+    }
+
+    // The button must appear ABOVE the name input fields so it stays visible
+    // when the on-screen keyboard is open (issue #19).
+    @Test
+    fun start_game_button_is_above_player_name_fields() {
+        launch()
+        // getBoundsInRoot() returns the position of each node on screen.
+        // We compare the bottom edge of the button with the top edge of the
+        // first name field: button.bottom must be less than field.top.
+        val buttonBounds = composeTestRule
+            .onNodeWithText("Start Game")
+            .getBoundsInRoot()
+        val fieldBounds = composeTestRule
+            .onNodeWithText("Player 1")
+            .getBoundsInRoot()
+
+        // The button's bottom edge should be above the first name-field's top edge.
+        assert(buttonBounds.bottom < fieldBounds.top) {
+            "Expected Start Game button (bottom=${buttonBounds.bottom}) to be above " +
+                "Player 1 field (top=${fieldBounds.top})"
+        }
     }
 
     @Test

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -160,13 +160,6 @@ fun LandingScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        Text(
-            text = strings.playerNamesLabel,
-            style = MaterialTheme.typography.titleMedium
-        )
-
-        Spacer(modifier = Modifier.height(12.dp))
-
         // Resolve display names: blank fields fall back to the localized "Player N" equivalent.
         // This ensures that leaving two fields blank is treated as a duplicate.
         val resolvedNames = playerNames.mapIndexed { i, name ->
@@ -181,6 +174,28 @@ fun LandingScreen(
 
         // The button is disabled and a warning is shown whenever any duplicate exists.
         val hasDuplicates = duplicateFlags.any { it }
+
+        // "Start Game" button placed ABOVE the name fields so it stays visible when the
+        // on-screen keyboard is open. The user can start immediately (names fall back to
+        // "Player N") or fill the fields first — either way the button is reachable
+        // without closing the keyboard.
+        // `enabled = !hasDuplicates` prevents starting a game when names clash.
+        Button(
+            onClick = { onStartGame(playerNames.toList()) },
+            enabled = !hasDuplicates,
+            modifier = Modifier.fillMaxWidth(0.8f)
+        ) {
+            Text(strings.startGame)
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = strings.playerNamesLabel,
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
 
         // Loop over each player slot and render a text field for their name.
         for (i in playerNames.indices) {
@@ -202,19 +217,7 @@ fun LandingScreen(
             )
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
-
-        // "Start Game" button. Tapping it calls `onStartGame` with a snapshot of the
-        // current names. `toList()` converts the mutable state list to a regular
-        // immutable List<String> so it's safe to pass to another screen.
-        // `enabled = !hasDuplicates` prevents starting a game when names clash.
-        Button(
-            onClick = { onStartGame(playerNames.toList()) },
-            enabled = !hasDuplicates,
-            modifier = Modifier.fillMaxWidth(0.8f)
-        ) {
-            Text(strings.startGame)
-        }
+        Spacer(modifier = Modifier.height(16.dp))
 
         // ── Past Games ────────────────────────────────────────────────────────
         // Only shown when there is at least one saved game on the device.

--- a/docs/player-setup.md
+++ b/docs/player-setup.md
@@ -7,6 +7,18 @@ The landing screen lets users configure a game before it starts. It currently ha
 1. **Choose the number of players** (3, 4, or 5)
 2. **Enter each player's name**
 
+## Layout
+
+The screen uses a scrollable `Column`. To keep the "Start Game" button reachable even when the on-screen keyboard is open, the button is placed **above** the name input fields. The layout order is:
+
+1. Language switcher (flag chips, top-right)
+2. App title
+3. Player count chips (3 / 4 / 5)
+4. **Start Game button** ← always visible above the keyboard
+5. Player name fields
+6. Resume Game card (if an unfinished game is saved)
+7. Past Games list (if any completed games exist)
+
 ## How it works
 
 ### Player count selection


### PR DESCRIPTION
## Summary

- Moves the "Start Game" button to appear **before** the player name text fields in the scrollable `Column`
- The button is now always visible above the on-screen keyboard — no need to dismiss it to start a game (fixes #19)
- Adds a Compose UI test asserting the button's vertical position is above the first name field
- Updates `docs/player-setup.md` with the updated layout order

## Test plan

- [ ] Launch the app on a device/emulator
- [ ] Tap a player name field — the keyboard opens
- [ ] Confirm "Start Game" button is visible without closing the keyboard
- [ ] Run `./gradlew connectedAndroidTest` — all `LandingScreenTest` cases pass, including the new `start_game_button_is_above_player_name_fields` test