### PR TITLE
feat(#18): move points range hint into field placeholder

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
@@ -64,7 +64,6 @@ data class AppStrings(
     val chooseContract: (taker: String) -> String,
     val skipRound: String,
     val numberOfBouts: String,
-    val pointsScoredByTaker: String,
     // Segmented-button label for the attacker (taker) side of the toggle.
     val attackerMode: String,
     // Segmented-button label for the defenders' side of the toggle.
@@ -163,7 +162,6 @@ val EnStrings = AppStrings(
     chooseContract        = { taker -> "$taker — choose a contract:" },
     skipRound             = "Skip round",
     numberOfBouts         = "Number of bouts (oudlers)",
-    pointsScoredByTaker   = "Points scored by taker",
     attackerMode          = "Attacker",
     defenderMode          = "Defenders",
     partnerCalledByTaker  = "Partner (called by taker)",
@@ -237,7 +235,6 @@ val FrStrings = AppStrings(
     chooseContract        = { taker -> "$taker — choisissez un contrat :" },
     skipRound             = "Passer la manche",
     numberOfBouts         = "Nombre de bouts (oudlers)",
-    pointsScoredByTaker   = "Points marqués par le preneur",
     attackerMode          = "Attaquant",
     defenderMode          = "Défenseurs",
     partnerCalledByTaker  = "Appelé (par le preneur)",

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -446,8 +446,6 @@ fun GameScreen(
                     }
                     // Right half: points entry — segmented toggle stacked above text field
                     Column(modifier = Modifier.weight(1f)) {
-                        FormLabel(strings.pointsScoredByTaker)
-                        Spacer(Modifier.height(8.dp))
                         // ── Camp toggle ────────────────────────────────────────
                         // The two segments let the user pick which camp's points to type.
                         // Selecting "Defenders" is a convenience — the taker's points are


### PR DESCRIPTION
## Summary

- Replaces the `0 – 91` supporting text below the points `OutlinedTextField` with a `0-91` placeholder inside the field itself
- Frees up vertical space on the game screen without losing any user-facing information
- Removes the now-unused `pointsRange` string from `AppStrings` and both EN/FR locale instances

## Test plan

- [x] Unit tests pass (`./gradlew testDebugUnitTest`)
- [x] Lint clean (`./gradlew lint`)
- [ ] Manually verify on device/emulator: the points field shows `0-91` as greyed-out placeholder text when empty, and the hint no longer appears below the field
- [ ] Verify the out-of-range error message still appears when a value > 91 is entered

Closes #18