### PR TITLE
feat(#21): improve game screen header layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ TarotCounter guides players through a game round by round:
 2. **Contract selection** — the current taker picks their contract (or skips)
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
 4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first
-5. **Score history table** — tap the bar-chart icon next to "Scores" to see a round-by-round table of cumulative scores for every player
-6. **End Game / Final Score** — tap "End Game" at any point to see the final results: winner card with total score, full round-by-round table (winner's column highlighted), and a "New Game" button
+5. **Score history table** — tap the bar-chart icon (left of the header) to see a round-by-round table of cumulative scores for every player
+6. **End Game / Final Score** — tap the checkered-flag icon (right of the header) at any point to see the final results: winner card with total score, full round-by-round table (winner's column highlighted), and a "New Game" button
 7. **Auto-save & Resume** — the game state is saved after every round; if the app is closed mid-game, a "Resume Game" card appears on the setup screen the next time it is opened
 8. **Past Games** — completed games are saved to the device; the setup screen shows a list of past results
 

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -219,7 +219,7 @@ class GameScreenTest {
     fun history_appears_after_first_round_is_skipped() {
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()
-        composeTestRule.onNodeWithText("History").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("History").assertIsDisplayed()
     }
 
     @Test
@@ -299,15 +299,15 @@ class GameScreenTest {
         // The History button only appears once at least one round has been recorded.
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()
-        // FilledTonalButton with text label — findable by its text.
-        composeTestRule.onNodeWithText("History").assertIsDisplayed()
+        // IconButton — findable by its contentDescription.
+        composeTestRule.onNodeWithContentDescription("History").assertIsDisplayed()
     }
 
     @Test
     fun tapping_score_history_button_opens_history_screen() {
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()
-        composeTestRule.onNodeWithText("History").performClick()
+        composeTestRule.onNodeWithContentDescription("History").performClick()
         composeTestRule.onNodeWithText("Score history").assertIsDisplayed()
     }
 
@@ -315,7 +315,7 @@ class GameScreenTest {
     fun back_button_on_history_screen_returns_to_game() {
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()  // complete round 1
-        composeTestRule.onNodeWithText("History").performClick()
+        composeTestRule.onNodeWithContentDescription("History").performClick()
         composeTestRule
             .onNodeWithContentDescription("Back to game")
             .performClick()
@@ -329,7 +329,7 @@ class GameScreenTest {
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()  // complete round 1
         composeTestRule.onNodeWithText("Garde").performClick()        // enter step 2
-        composeTestRule.onNodeWithText("History").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("History").assertIsDisplayed()
     }
 
     @Test
@@ -354,13 +354,13 @@ class GameScreenTest {
     fun end_game_button_is_displayed_on_step_1_from_the_start() {
         // "End Game" must be visible even before any round has been played.
         launchGame()
-        composeTestRule.onNodeWithText("End Game").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("End Game").assertIsDisplayed()
     }
 
     @Test
     fun tapping_end_game_on_step_1_opens_final_score_screen() {
         launchGame()
-        composeTestRule.onNodeWithText("End Game").performClick()
+        composeTestRule.onNodeWithContentDescription("End Game").performClick()
         composeTestRule.onNodeWithText("Game Over").assertIsDisplayed()
     }
 
@@ -369,21 +369,21 @@ class GameScreenTest {
         // After selecting a contract, the End Game button should appear in the details form.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
-        composeTestRule.onNodeWithText("End Game").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("End Game").assertIsDisplayed()
     }
 
     @Test
     fun tapping_end_game_on_step_2_opens_final_score_screen() {
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
-        composeTestRule.onNodeWithText("End Game").performClick()
+        composeTestRule.onNodeWithContentDescription("End Game").performClick()
         composeTestRule.onNodeWithText("Game Over").assertIsDisplayed()
     }
 
     @Test
     fun final_score_screen_shows_new_game_button() {
         launchGame()
-        composeTestRule.onNodeWithText("End Game").performClick()
+        composeTestRule.onNodeWithContentDescription("End Game").performClick()
         composeTestRule.onNodeWithText("New Game").assertIsDisplayed()
     }
 
@@ -392,7 +392,7 @@ class GameScreenTest {
         // Complete one round so there is a score to show, then end the game.
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()  // complete round 1
-        composeTestRule.onNodeWithText("End Game").performClick()
+        composeTestRule.onNodeWithContentDescription("End Game").performClick()
         composeTestRule.onNodeWithText("Game Over").assertIsDisplayed()
 
         // Tapping "Back to game" should return to the active round.
@@ -403,7 +403,7 @@ class GameScreenTest {
     @Test
     fun back_arrow_on_final_score_screen_returns_to_game() {
         launchGame()
-        composeTestRule.onNodeWithText("End Game").performClick()
+        composeTestRule.onNodeWithContentDescription("End Game").performClick()
         composeTestRule
             .onNodeWithContentDescription("Back to game")
             .performClick()

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -1,6 +1,7 @@
 package fr.mandarine.tarotcounter
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -13,24 +14,21 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
-import androidx.compose.material.icons.filled.Flag
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.SportsScore
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -233,21 +231,35 @@ fun GameScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
 
-        // ── Header: round number + action buttons ─────────────────────────────
-        Row(
+        // ── Header: history button | centered round number | end-game button ──
+        // Box lets us layer two Rows: one for the side buttons (SpaceBetween)
+        // and one for the centered title, so the title is truly centered
+        // regardless of the buttons' widths.
+        Box(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
+            contentAlignment = Alignment.Center
         ) {
+            // Centered round label — always in the middle of the full width.
             Text(
                 text = strings.roundHeader(currentRound),
-                style = MaterialTheme.typography.headlineMedium
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center
             )
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            // Side buttons sit in a Row that spans the full width.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // History button — only shown once at least one round has been recorded.
                 if (roundHistory.isNotEmpty()) {
                     HistoryButton(onClick = { showScoreHistory = true })
-                    Spacer(Modifier.width(8.dp))
+                } else {
+                    // Invisible placeholder keeps the round number centered even
+                    // when the history button is not yet visible.
+                    Spacer(Modifier.size(48.dp))
                 }
+                // End Game button — always shown so the user can stop at any time.
                 EndGameButton(onClick = { showEndGameDialog = true })
             }
         }
@@ -790,35 +802,33 @@ private fun CompactScoreboard(
 
 // ── Shared composables ────────────────────────────────────────────────────────
 
-// A tonal button with a bar-chart icon and the localized "History" label.
-// Used in the game screen header to open the full score history overlay.
+// An icon-only button with a bar-chart icon for opening the score history overlay.
+// Using IconButton (no text) keeps the header compact; the contentDescription
+// ensures screen readers still announce the purpose of the button.
 @Composable
 fun HistoryButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
     val strings = appStrings(LocalAppLocale.current)
-    FilledTonalButton(onClick = onClick, modifier = modifier) {
+    IconButton(onClick = onClick, modifier = modifier) {
         Icon(
             imageVector        = Icons.Default.BarChart,
-            contentDescription = null,
-            modifier           = Modifier.size(ButtonDefaults.IconSize)
+            // Accessible label read by TalkBack — same text that was previously the button label.
+            contentDescription = strings.history
         )
-        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-        Text(strings.history)
     }
 }
 
-// A tonal button with a flag icon and the localized "End Game" label.
-// Always shown so the user can stop the game at any point.
+// An icon-only button with a checkered-flag icon for ending the game.
+// SportsScore (a finish/checkered flag) is clearer than the generic Flag icon
+// and matches the "stop / finish line" semantic requested in issue #21.
 @Composable
 fun EndGameButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
     val strings = appStrings(LocalAppLocale.current)
-    FilledTonalButton(onClick = onClick, modifier = modifier) {
+    IconButton(onClick = onClick, modifier = modifier) {
         Icon(
-            imageVector        = Icons.Default.Flag,
-            contentDescription = null,
-            modifier           = Modifier.size(ButtonDefaults.IconSize)
+            imageVector        = Icons.Default.SportsScore,
+            // Accessible label read by TalkBack.
+            contentDescription = strings.endGame
         )
-        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-        Text(strings.endGame)
     }
 }
 

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -161,7 +161,15 @@ Round 1: Alice — Garde · 2 bouts · 56 pts — Won (+80)
 
 Skipped rounds show no outcome and do not affect scores.
 
-The **History** button in the top-right corner opens a full scrollable score table overlay (with running cumulative totals) for detailed review.
+#### Header
+
+The game screen header has three zones:
+
+| Left | Center | Right |
+|------|--------|-------|
+| **History** icon button (bar-chart icon) — opens the full score history overlay. Only shown after at least one round has been recorded. | **Round N** — the current round number, always centered. | **End Game** icon button (checkered-flag icon) — always shown, opens a confirmation dialog before stopping the game. |
+
+The **History** icon button opens a full scrollable score table overlay (with running cumulative totals) for detailed review.
 
 ## Data Model
 


### PR DESCRIPTION
## Summary

- Replaces the full text+icon `FilledTonalButton`s with compact icon-only `IconButton`s in the game screen header
- Centers the round number (`Round N`) using a `Box` overlay so it stays truly centered regardless of button visibility
- Swaps the `Flag` icon for `SportsScore` (checkered flag) on the End Game button — clearer "finish line" semantic as requested in the issue
- Keeps `contentDescription` on both buttons for TalkBack/accessibility
- Adds an invisible 48dp `Spacer` in place of the History button (before round 1 is done) to keep the round number centered

## Test plan

- [ ] UI tests updated: `onNodeWithText("History")` / `onNodeWithText("End Game")` → `onNodeWithContentDescription(...)` since buttons no longer have visible text labels
- [ ] Unit tests pass: `./gradlew testDebugUnitTest` ✅
- [ ] Lint passes: `./gradlew lint` ✅
- [ ] Verify on device: header shows bar-chart icon left, "Round N" centered, checkered-flag icon right

Closes #21