### PR TITLE
feat(#23): align oudlers dropdown and points field at the bottom

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -401,9 +401,12 @@ fun GameScreen(
                 // ── Bouts + Points side by side ───────────────────────────────
                 // Placing these in a Row cuts one section of vertical space compared
                 // to stacking them, helping everything fit on one screen.
+                // Alignment.Bottom ensures both halves share the same bottom edge,
+                // so the dropdown and the text field line up visually (issue #23).
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalAlignment = Alignment.Bottom
                 ) {
                     // Left half: bouts dropdown
                     // Replaced from FilterChips to an ExposedDropdownMenuBox to save


### PR DESCRIPTION
## Summary

- Adds `verticalAlignment = Alignment.Bottom` to the `Row` that holds the bouts (oudlers) dropdown and the points column
- Ensures both halves share the same bottom edge regardless of how many stacked widgets each side contains (the points side has a segmented button above its text field, making it taller than the bouts side)

Fixes #23

## Test plan

- [x] Build and run on a device/emulator
- [x] Select a contract on the game screen and verify the oudlers dropdown and the points text field are aligned at the bottom
- [ ] Unit tests pass: `./gradlew testDebugUnitTest`