### PR TITLE
feat(#3): standardize layout padding and header patterns across screens

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material3.Button
@@ -23,7 +22,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -91,37 +89,24 @@ fun FinalScoreScreen(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp, vertical = 16.dp),
+            .padding(horizontal = 24.dp, vertical = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
 
-        // ── Back arrow ────────────────────────────────────────────────────────
-        // Lets the user return to the game if they tapped "End Game" by mistake.
-        // Placed at the leading edge of a full-width row, mirroring ScoreHistoryScreen.
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = onBack) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = strings.backToGame
-                )
-            }
-        }
+        // ── Screen header: back arrow + title ─────────────────────────────────
+        // ScreenHeader is a shared composable (ScreenHeader.kt) that renders the
+        // back arrow and screen title in a Row — the same pattern as ScoreHistoryScreen,
+        // now unified into one place so both screens look identical at the top.
+        ScreenHeader(title = strings.gameOver, onBack = onBack)
 
-        // ── Title ─────────────────────────────────────────────────────────────
-        // The icon is decorative — the heading already conveys "game over".
+        // ── Decorative trophy icon ─────────────────────────────────────────────
+        // The icon is purely decorative; the title above already conveys "game over".
+        Spacer(modifier = Modifier.height(8.dp))
         Icon(
             imageVector = Icons.Default.EmojiEvents,
             contentDescription = null,
             modifier = Modifier.size(48.dp),
             tint = MaterialTheme.colorScheme.primary
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = strings.gameOver,
-            style = MaterialTheme.typography.headlineMedium
         )
 
         Spacer(modifier = Modifier.height(20.dp))

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -227,7 +227,7 @@ fun GameScreen(
             .fillMaxSize()
             .imePadding()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 24.dp, vertical = 12.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
 

--- a/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
@@ -13,11 +13,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -71,23 +69,15 @@ fun ScoreHistoryScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            // verticalScroll on the outer Column scrolls the entire page (header + table)
+            // vertically, so long game histories never clip off-screen.
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp, vertical = 8.dp)
     ) {
         // ── Screen header: back arrow + title ─────────────────────────────────
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            // Tapping the back arrow returns to the game without losing any state,
-            // because `showScoreHistory` in GameScreen just flips back to false.
-            IconButton(onClick = onBack) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                    contentDescription = strings.backToGame
-                )
-            }
-            Text(
-                text = strings.scoreHistory,
-                style = MaterialTheme.typography.headlineSmall
-            )
-        }
+        // ScreenHeader is the shared composable defined in ScreenHeader.kt —
+        // it renders a back arrow + title in a Row, consistent with FinalScoreScreen.
+        ScreenHeader(title = strings.scoreHistory, onBack = onBack)
 
         Spacer(modifier = Modifier.height(8.dp))
         HorizontalDivider()
@@ -105,9 +95,9 @@ fun ScoreHistoryScreen(
         val hScrollState = rememberScrollState()
         Box {
             Column(
-                modifier = Modifier
-                    .horizontalScroll(hScrollState)
-                    .verticalScroll(rememberScrollState())
+                // Only horizontal scrolling here — vertical scrolling is handled
+                // by the outer Column so the two scroll directions don't conflict.
+                modifier = Modifier.horizontalScroll(hScrollState)
             ) {
                 // Column headers: localized "Round" header, then one header per player name.
                 ScoreTableRow(

--- a/app/src/main/java/fr/mandarine/tarotcounter/ScreenHeader.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/ScreenHeader.kt
@@ -1,0 +1,57 @@
+package fr.mandarine.tarotcounter
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * ScreenHeader is a shared navigation header used by overlay screens
+ * (FinalScoreScreen, ScoreHistoryScreen) to ensure a consistent look.
+ *
+ * It renders a back-arrow [IconButton] on the leading edge followed by the
+ * screen [title] in headlineSmall style — the same visual pattern that was
+ * previously hand-coded in ScoreHistoryScreen.
+ *
+ * @param title    The screen title displayed next to the back arrow.
+ * @param onBack   Called when the user taps the back arrow.
+ * @param modifier Optional modifier forwarded to the outer [Row].
+ */
+@Composable
+fun ScreenHeader(
+    title: String,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Read the active locale so the back-arrow accessibility label is localized,
+    // matching the pattern used in every other composable in this project.
+    val strings = appStrings(LocalAppLocale.current)
+
+    // Row aligns its children horizontally: arrow on the left, title to its right.
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // IconButton provides a touch-target around the arrow icon.
+        // contentDescription is read by screen-readers (accessibility).
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = strings.backToGame
+            )
+        }
+
+        // headlineSmall matches the weight used in ScoreHistoryScreen's original header.
+        Text(
+            text = title,
+            style = MaterialTheme.typography.headlineSmall
+        )
+    }
+}

--- a/docs/final-score.md
+++ b/docs/final-score.md
@@ -14,10 +14,9 @@ The game can be ended at any time — even before the first round is played.
 ## Layout
 
 ```
-← (back arrow)
+← Game Over          ← shared ScreenHeader (back arrow + title in one row)
 
 [ Trophy icon ]
-   Game Over
 
 ╔══════════════════════════╗
 ║         Winner           ║  ← "Winner" label (or "It's a tie!")
@@ -58,7 +57,7 @@ The **winner's column** is highlighted with a `secondaryContainer` tint and bold
 
 | Action | Where | What it does |
 |---|---|---|
-| Back arrow (top-left) | `IconButton` | Returns to the active game round. No state is lost. |
+| Back arrow (top-left) | `ScreenHeader` | Returns to the active game round. No state is lost. |
 | **Back to game** | `OutlinedButton` (bottom) | Same as the back arrow — resumes the current game. |
 | **New Game** | `Button` (bottom, primary) | Navigates to the setup screen. All game state is discarded. |
 
@@ -67,6 +66,7 @@ The back arrow and "Back to game" button serve the same purpose: letting the use
 ## Related Files
 
 - `FinalScoreScreen.kt` — Composable implementation
+- `ScreenHeader.kt` — Shared back-arrow + title header used by this screen and `ScoreHistoryScreen`
 - `GameModels.kt` — `computeFinalTotals()` and `findWinners()` pure functions
 - `GameScreen.kt` — `EndGameButton` composable, `showFinalScore` state, routing
 - `RoundDetailsForm.kt` — `EndGameButton` in the form header

--- a/docs/score-history.md
+++ b/docs/score-history.md
@@ -25,8 +25,10 @@ A bar-chart icon button (⬛) appears to the right of the "Scores" heading on th
 
 ## Scrolling
 
-- **Horizontal scroll** — for 5-player games where the table is wider than the screen.
-- **Vertical scroll** — for long games with many rounds.
+- **Horizontal scroll** — for 5-player games where the table is wider than the screen (applied to the inner table Column).
+- **Vertical scroll** — for long games with many rounds (applied to the outer Column so the full page, including the header, scrolls together).
+
+The two scroll directions are intentionally separated: the outer Column owns vertical scrolling, and the inner table Column owns horizontal scrolling. This prevents scroll gesture conflicts.
 
 ## Navigation
 


### PR DESCRIPTION
## Summary

- All screens now use `horizontal = 24.dp` padding (`GameScreen`, `FinalScoreScreen`, `ScoreHistoryScreen` were on `16.dp`; `LandingScreen` was already correct)
- New shared `ScreenHeader(title, onBack)` composable in `ScreenHeader.kt` replaces two divergent hand-coded header patterns: `FinalScoreScreen`'s arrow-only `Row` and `ScoreHistoryScreen`'s arrow+title `Row`
- `ScoreHistoryScreen` outer `Column` now owns vertical scrolling; the inner table `Column` is horizontal-only — preventing scroll-gesture conflicts and ensuring long game histories don't clip

## Test plan

- [ ] Run `./gradlew testDebugUnitTest` — all 24 unit tests pass
- [ ] Run `./gradlew lint` — no new warnings
- [ ] Run `./gradlew connectedAndroidTest` on a device to verify `ScoreHistoryScreenTest` and `FinalScoreScreenTest` still pass (back arrow, title, cumulative scores all displayed correctly)
- [ ] Manually verify all four screens look visually consistent with the wider `24.dp` padding

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)