### PR TITLE
feat(#5): LandingScreen identity and card polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ An Android app for tracking scores in **French Tarot**, a classic French trick-t
 
 TarotCounter guides players through a game round by round:
 
-1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique
+1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone
 2. **Contract selection** — the current taker picks their contract (or skips)
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
 4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first
 5. **Score history table** — tap the bar-chart icon (left of the header) to see a round-by-round table of cumulative scores for every player
 6. **End Game / Final Score** — tap the checkered-flag icon (right of the header) at any point to see the final results: winner card with total score, full round-by-round table (winner's column highlighted), and a "New Game" button
 7. **Auto-save & Resume** — the game state is saved after every round; if the app is closed mid-game, a "Resume Game" card appears on the setup screen the next time it is opened
-8. **Past Games** — completed games are saved to the device; the setup screen shows a list of past results
+8. **Past Games** — completed games are saved to the device; the setup screen shows a list of past results with a trophy icon next to the winner's name
 
 The app automatically rotates the taker each round, determines win/loss, and computes each player's score for the round.
 

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
@@ -40,6 +41,25 @@ class LandingScreenTest {
         composeTestRule.setContent {
             TarotCounterTheme {
                 LandingScreen(onStartGame = onStartGame)
+            }
+        }
+    }
+
+    /** Launches LandingScreen with a list of past games so the history section appears. */
+    private fun launchWithPastGames() {
+        composeTestRule.setContent {
+            TarotCounterTheme {
+                LandingScreen(
+                    pastGames = listOf(
+                        SavedGame(
+                            id = "test-1",
+                            datestamp = System.currentTimeMillis(),
+                            playerNames = listOf("Alice", "Bob", "Charlie"),
+                            rounds = emptyList(),
+                            finalScores = mapOf("Alice" to 150, "Bob" to -75, "Charlie" to -75)
+                        )
+                    )
+                )
             }
         }
     }
@@ -244,5 +264,51 @@ class LandingScreenTest {
 
         // No more duplicates → button enabled again.
         composeTestRule.onNodeWithText("Start Game").assertIsEnabled()
+    }
+
+    // ── Spec: decorative card-suit header (issue #5) ──────────────────────────
+
+    @Test
+    fun card_suit_symbols_are_shown_above_title() {
+        launch()
+        // The four French tarot suit symbols should appear on screen.
+        composeTestRule.onNodeWithText("♠  ♥  ♦  ♣").assertIsDisplayed()
+    }
+
+    @Test
+    fun card_suit_symbols_are_above_app_title() {
+        launch()
+        // The suit symbols must appear above the title — same spatial check used for
+        // the "Start Game" button position test.
+        val suitBounds = composeTestRule
+            .onNodeWithText("♠  ♥  ♦  ♣")
+            .getBoundsInRoot()
+        val titleBounds = composeTestRule
+            .onNodeWithText("Tarot Counter")
+            .getBoundsInRoot()
+
+        assert(suitBounds.bottom <= titleBounds.top) {
+            "Expected suit symbols (bottom=${suitBounds.bottom}) to be above " +
+                "app title (top=${titleBounds.top})"
+        }
+    }
+
+    // ── Spec: "Past Games" section heading weight (issue #5) ─────────────────
+
+    @Test
+    fun past_games_heading_is_displayed_when_history_exists() {
+        launchWithPastGames()
+        // The "Past Games" heading must be visible.
+        composeTestRule.onNodeWithText("Past Games").assertIsDisplayed()
+    }
+
+    // ── Spec: past game card shows winner name (issue #5) ─────────────────────
+
+    @Test
+    fun past_game_card_shows_winner_line() {
+        launchWithPastGames()
+        // The winner result text should appear (e.g. "Alice +150") inside the card.
+        // We use a substring check via containsText to stay locale-agnostic.
+        composeTestRule.onNodeWithText("Alice", substring = true).assertIsDisplayed()
     }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -1,6 +1,8 @@
 package fr.mandarine.tarotcounter
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,14 +11,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -106,6 +112,18 @@ fun LandingScreen(
         }
 
         Spacer(modifier = Modifier.height(8.dp))
+
+        // ── Decorative card-suit row ───────────────────────────────────────────
+        // The four French tarot suit symbols serve as a thematic header above the
+        // app title, giving the screen a card-game identity at a glance.
+        // `displaySmall` is a large, airy text style — perfect for decorative glyphs.
+        Text(
+            text = "♠  ♥  ♦  ♣",
+            style = MaterialTheme.typography.displaySmall,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
 
         // Text displays a string. MaterialTheme.typography gives us pre-defined
         // text styles that match Material Design (headlineLarge is a big bold title).
@@ -223,12 +241,16 @@ fun LandingScreen(
         // Only shown when there is at least one saved game on the device.
         if (pastGames.isNotEmpty()) {
             Spacer(modifier = Modifier.height(40.dp))
-            HorizontalDivider()
+            // A divider with generous vertical padding clearly separates the
+            // setup section (above) from the historical games list (below).
+            HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
             Spacer(modifier = Modifier.height(16.dp))
 
+            // titleLarge gives the section heading more visual weight than titleMedium,
+            // improving the hierarchy between the section label and the cards below it.
             Text(
                 text = strings.pastGames,
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.titleLarge,
                 modifier = Modifier.fillMaxWidth()
             )
 
@@ -259,6 +281,11 @@ private fun ResumeGameCard(
     // Builds e.g. "Round 3 · 2 rounds played" using the localized templates.
     val roundLabel = strings.roundsPlayed(roundsPlayed)
 
+    // Capture primary color here so it can be used inside the Box below.
+    // Composable functions can only be called from within a @Composable scope,
+    // so we read MaterialTheme values before we enter the Card content lambda.
+    val accentColor = MaterialTheme.colorScheme.primary
+
     Card(
         modifier = Modifier.fillMaxWidth(),
         // Elevated shadow makes the Resume card stand out from the Past Games list below
@@ -268,40 +295,53 @@ private fun ResumeGameCard(
             containerColor = MaterialTheme.colorScheme.primaryContainer
         )
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 14.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            // titleMedium (vs the previous labelLarge) gives the card a clear heading
-            // that's immediately readable at a glance — matching the visual weight
-            // of a section title rather than a small chip label.
-            Text(
-                text = strings.resumeGameTitle,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
+        // Box layers its children on top of each other.
+        // The first child (the colored strip) sits at the start edge;
+        // the second child (the content) fills the remaining space.
+        Row(modifier = Modifier.fillMaxWidth()) {
+            // A narrow vertical strip in the primary color acts as an accent border
+            // on the left side of the card, giving it extra visual emphasis.
+            Box(
+                modifier = Modifier
+                    .width(4.dp)
+                    .height(120.dp)           // tall enough to cover typical card content
+                    .background(accentColor)
             )
-            Text(
-                // Show which players are in the game.
-                text = game.playerNames.joinToString(", "),
-                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
-                color = MaterialTheme.colorScheme.onPrimaryContainer
-            )
-            Text(
-                // Show how far the game has progressed, e.g. "Round 4 · 3 rounds played".
-                text = strings.resumeRoundDetail(game.currentRound, roundLabel),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            Button(
-                onClick = onResume,
-                modifier = Modifier.fillMaxWidth()
+            Column(
+                modifier = Modifier
+                    .weight(1f)               // fill remaining horizontal space after the strip
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                Text(strings.resume)
+                // titleMedium (vs the previous labelLarge) gives the card a clear heading
+                // that's immediately readable at a glance — matching the visual weight
+                // of a section title rather than a small chip label.
+                Text(
+                    text = strings.resumeGameTitle,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                Text(
+                    // Show which players are in the game.
+                    text = game.playerNames.joinToString(", "),
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                Text(
+                    // Show how far the game has progressed, e.g. "Round 4 · 3 rounds played".
+                    text = strings.resumeRoundDetail(game.currentRound, roundLabel),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Button(
+                    onClick = onResume,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(strings.resume)
+                }
             }
-        }
+        }   // end Row (accent strip + content)
     }
 }
 
@@ -350,11 +390,27 @@ private fun PastGameCard(game: SavedGame, strings: AppStrings) {
                 text = game.playerNames.joinToString(", "),
                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
             )
-            // Winner (or tie) on the second line.
-            Text(
-                text = winnerText,
-                style = MaterialTheme.typography.bodyMedium
-            )
+            // Winner (or tie) on the second line, with a small trophy icon on the left.
+            // Row arranges the icon and text side by side, vertically centered.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                // Only show the trophy when there is an actual winner (not a tie or no rounds).
+                // winners.size == 1 means a single player came out on top.
+                if (winners.size == 1) {
+                    Icon(
+                        imageVector = Icons.Default.EmojiEvents,
+                        contentDescription = null, // decorative icon — screen readers skip it
+                        modifier = Modifier.size(16.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+                Text(
+                    text = winnerText,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
             // Round count and date on the third line, separated by a dot.
             Text(
                 text = "${strings.roundCount(roundCount)} · $dateStr",

--- a/docs/player-setup.md
+++ b/docs/player-setup.md
@@ -12,12 +12,28 @@ The landing screen lets users configure a game before it starts. It currently ha
 The screen uses a scrollable `Column`. To keep the "Start Game" button reachable even when the on-screen keyboard is open, the button is placed **above** the name input fields. The layout order is:
 
 1. Language switcher (flag chips, top-right)
-2. App title
-3. Player count chips (3 / 4 / 5)
-4. **Start Game button** ← always visible above the keyboard
-5. Player name fields
-6. Resume Game card (if an unfinished game is saved)
-7. Past Games list (if any completed games exist)
+2. Card-suit decorative header (`♠ ♥ ♦ ♣`, in primary color)
+3. App title
+4. Player count chips (3 / 4 / 5)
+5. **Start Game button** ← always visible above the keyboard
+6. Player name fields
+7. Resume Game card (if an unfinished game is saved)
+8. Past Games list (if any completed games exist)
+
+## Visual design
+
+### Decorative card-suit header
+
+A row of the four French tarot suit symbols (`♠ ♥ ♦ ♣`) appears above the app title using `displaySmall` typography and the `primary` theme color. This gives the screen an immediate card-game identity without requiring custom images.
+
+### Resume Game card accent border
+
+The `ResumeGameCard` includes a 4 dp wide vertical strip in the `primary` color on its left edge. This is achieved by placing a thin `Box` and the card's `Column` content side by side in a `Row` inside the card. The strip acts as an accent border that distinguishes the active-game card visually from the passive history cards below.
+
+### Past Games section
+
+- The section heading uses `titleLarge` (previously `titleMedium`) for stronger visual hierarchy.
+- Each `PastGameCard` displays a small trophy icon (`Icons.Default.EmojiEvents`) inline with the winner name when a single winner exists. Tie results and no-rounds results do not show the trophy.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

- Adds a `♠ ♥ ♦ ♣` decorative row above the app title (primary color, `displaySmall` style) to give the screen immediate card-game identity
- Adds a 4 dp primary-color accent strip on the left edge of `ResumeGameCard` using a `Row + Box` layout inside the card
- Adds a small `EmojiEvents` trophy icon inline with the winner name in `PastGameCard` (single-winner only; tie/no-rounds skipped)
- Upgrades the "Past Games" heading from `titleMedium` → `titleLarge` for stronger visual hierarchy
- Adds `HorizontalDivider` with vertical padding between the setup section and the past-games list

## Test plan

- [x] New Compose UI tests: `card_suit_symbols_are_shown_above_title`, `card_suit_symbols_are_above_app_title`, `past_games_heading_is_displayed_when_history_exists`, `past_game_card_shows_winner_line`
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL
- [x] `./gradlew lint` — BUILD SUCCESSFUL

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)