### PR TITLE
feat(#6): styled round history rows with color indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ TarotCounter guides players through a game round by round:
 1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone
 2. **Contract selection** — the current taker picks their contract (or skips)
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
-4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first
+4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first; each history row shows a colored **●** indicator (green = won, red = lost, grey = skipped) for at-a-glance scanning
 5. **Score history table** — tap the bar-chart icon (left of the header) to see a round-by-round table of cumulative scores for every player
 6. **End Game / Final Score** — tap the checkered-flag icon (right of the header) at any point to see the final results: winner card with total score, full round-by-round table (winner's column highlighted in gold/amber), and a "New Game" button
 7. **Colour-coded scores** — positive scores appear in green and negative scores in red across all score views (CompactScoreboard, ScoreHistoryScreen, FinalScoreScreen); colours adapt to light/dark theme automatically

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -464,4 +464,61 @@ class GameScreenTest {
 
         composeTestRule.onNodeWithText("Confirm round").assertIsEnabled()
     }
+
+    // ── Spec: styled round history rows (issue #6) ────────────────────────────
+    // Each history row must have a colored indicator dot whose testTag encodes
+    // the outcome: "round_indicator_won", "round_indicator_lost",
+    // or "round_indicator_skipped".
+
+    @Test
+    fun skipped_round_shows_skipped_indicator() {
+        // A skipped round must display the grey (skipped) indicator dot.
+        launchGame()
+        composeTestRule.onNodeWithText("Skip round").performClick()
+
+        // The indicator tagged "round_indicator_skipped" must be visible.
+        composeTestRule.onNodeWithTag("round_indicator_skipped").assertIsDisplayed()
+    }
+
+    @Test
+    fun lost_round_shows_lost_indicator() {
+        // Default form values: 0 bouts, 0 points → taker needs 56 to win → Lost.
+        launchGame()
+        composeTestRule.onNodeWithText("Garde").performClick()
+        composeTestRule.onNodeWithText("Confirm round").performClick()
+
+        // The indicator tagged "round_indicator_lost" must be visible.
+        composeTestRule.onNodeWithTag("round_indicator_lost").assertIsDisplayed()
+    }
+
+    @Test
+    fun won_round_shows_won_indicator() {
+        // 3 bouts, 91 points → needs only 36 → Won.
+        launchGame()
+        composeTestRule.onNodeWithText("Garde").performClick()
+
+        // Select 3 bouts from the dropdown.
+        composeTestRule.onNodeWithTag("bouts_dropdown").performClick()
+        composeTestRule.onAllNodesWithText("3")[0].performClick()
+
+        // Enter a winning score (91 pts with 3 bouts → 91 ≥ 36 → Won).
+        composeTestRule.onNodeWithTag("points_input").performTextInput("91")
+
+        composeTestRule.onNodeWithText("Confirm round").performClick()
+
+        // The indicator tagged "round_indicator_won" must be visible.
+        composeTestRule.onNodeWithTag("round_indicator_won").assertIsDisplayed()
+    }
+
+    @Test
+    fun multiple_rounds_show_correct_indicators() {
+        // Play one skipped + one lost round and verify both indicators appear.
+        launchGame()
+        composeTestRule.onNodeWithText("Skip round").performClick()   // round 1 → skipped
+        composeTestRule.onNodeWithText("Garde").performClick()
+        composeTestRule.onNodeWithText("Confirm round").performClick() // round 2 → lost (0 pts)
+
+        composeTestRule.onNodeWithTag("round_indicator_skipped").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("round_indicator_lost").assertIsDisplayed()
+    }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -723,30 +723,18 @@ fun GameScreen(
             HorizontalDivider()
             Spacer(Modifier.height(12.dp))
 
-            for (round in roundHistory.reversed()) {
-                // Build each part of the history line from localized string templates.
-                val contractText = round.contract?.localizedName(locale) ?: strings.skipped
-                val detailsText  = round.details?.let {
-                    strings.boutsPointsDetail(it.bouts, it.points)
-                } ?: ""
-                val takerScore = round.playerScores[round.takerName]
-                val outcomeText = when (round.won) {
-                    true  -> {
-                        val s = if (takerScore != null) " (+$takerScore)" else ""
-                        strings.wonOutcome(s)
-                    }
-                    false -> {
-                        val s = if (takerScore != null) " ($takerScore)" else ""
-                        strings.lostOutcome(s)
-                    }
-                    null  -> ""
+            // reversed() so the latest round appears first (newest-first order).
+            val reversedHistory = roundHistory.reversed()
+            reversedHistory.forEachIndexed { index, round ->
+                RoundHistoryRow(round = round, locale = locale, strings = strings)
+                // Draw a thin divider between rows (but not after the last one).
+                if (index < reversedHistory.lastIndex) {
+                    HorizontalDivider(
+                        modifier  = Modifier.padding(vertical = 4.dp),
+                        thickness = 0.5.dp,
+                        color     = MaterialTheme.colorScheme.outlineVariant
+                    )
                 }
-                Text(
-                    text  = strings.roundHistoryPrefix(round.roundNumber, round.takerName) +
-                            contractText + detailsText + outcomeText,
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Spacer(Modifier.height(4.dp))
             }
         }
     }
@@ -834,6 +822,86 @@ fun EndGameButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
             imageVector        = Icons.Default.SportsScore,
             // Accessible label read by TalkBack.
             contentDescription = strings.endGame
+        )
+    }
+}
+
+// ── Round history row ─────────────────────────────────────────────────────────
+
+// A single styled row in the round history list.
+//
+// Layout:  [●]  Round N: Taker — Contract · details — Outcome
+//
+// The leading dot (●) is colored by outcome so the user can scan results at a
+// glance without reading the text:
+//   Won     → MaterialTheme.colorScheme.primary   (green)
+//   Lost    → MaterialTheme.colorScheme.error     (red)
+//   Skipped → MaterialTheme.colorScheme.onSurfaceVariant (muted grey)
+//
+// All colors come from Material theme tokens — never hardcoded hex values —
+// so they automatically adapt to light vs. dark mode.
+//
+// The `testTag` on the indicator dot lets UI tests assert the correct color
+// semantic without reading color values directly.
+@Composable
+private fun RoundHistoryRow(
+    round:   RoundResult,
+    locale:  AppLocale,
+    strings: AppStrings
+) {
+    // ── Build text segments ────────────────────────────────────────────────
+    val contractText = round.contract?.localizedName(locale) ?: strings.skipped
+    val detailsText  = round.details?.let {
+        strings.boutsPointsDetail(it.bouts, it.points)
+    } ?: ""
+    val takerScore   = round.playerScores[round.takerName]
+    val outcomeText  = when (round.won) {
+        true  -> {
+            val s = if (takerScore != null) " (+$takerScore)" else ""
+            strings.wonOutcome(s)
+        }
+        false -> {
+            val s = if (takerScore != null) " ($takerScore)" else ""
+            strings.lostOutcome(s)
+        }
+        null  -> ""
+    }
+
+    // ── Choose indicator color and test tag by outcome ─────────────────────
+    // `Pair<Color, String>` groups the color token with the test tag so
+    // the when expression is compact and both values stay in sync.
+    val (indicatorColor, indicatorTag) = when (round.won) {
+        true  -> MaterialTheme.colorScheme.primary         to "round_indicator_won"
+        false -> MaterialTheme.colorScheme.error           to "round_indicator_lost"
+        null  -> MaterialTheme.colorScheme.onSurfaceVariant to "round_indicator_skipped"
+    }
+
+    // ── Row: indicator dot + history text ──────────────────────────────────
+    Row(
+        modifier          = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.Top
+    ) {
+        // Colored ● indicator — the key visual cue for won/lost/skipped.
+        // `bodyMedium` matches the text size so the dot aligns with the
+        // first line of the history text.
+        Text(
+            text     = "●  ",
+            style    = MaterialTheme.typography.bodyMedium,
+            color    = indicatorColor,
+            modifier = Modifier.testTag(indicatorTag)
+        )
+
+        // Main history text — same content as before, now on the right of the dot.
+        // `weight(1f)` lets the text wrap naturally without pushing the dot away.
+        Text(
+            text     = strings.roundHistoryPrefix(round.roundNumber, round.takerName) +
+                       contractText + detailsText + outcomeText,
+            style    = MaterialTheme.typography.bodyMedium,
+            // Prevent very long player names or bonus lists from causing layout overflow.
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f)
         )
     }
 }

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -146,7 +146,17 @@ The partner (5-player) does not participate in the poignée bonus exchange. The 
 
 After the first round is completed the game screen shows a persistent **compact scoreboard** at the top of the page — one column per player with their name and running total. This stays visible at all times without opening a separate screen.
 
-Below the round input, a full round-by-round log is displayed newest-first:
+Below the round input, a full round-by-round log is displayed newest-first.
+Each row begins with a colored **●** indicator so the outcome is readable at a glance
+without reading the text:
+
+| Indicator color | Outcome  |
+|-----------------|----------|
+| Green (primary) | Won      |
+| Red (error)     | Lost     |
+| Grey (muted)    | Skipped  |
+
+All indicator colors are Material theme tokens, adapting automatically to light and dark mode.
 
 ```
 Scores
@@ -155,11 +165,15 @@ Scores
 │  +80    -40     -40     │
 └─────────────────────────┘
 
-Round 2: Bob — Prise · 0 bouts · 50 pts — Lost (-31)
-Round 1: Alice — Garde · 2 bouts · 56 pts — Won (+80)
+●  Round 2: Bob — Prise · 0 bouts · 50 pts — Lost (-31)
+●  Round 1: Alice — Garde · 2 bouts · 56 pts — Won (+80)
 ```
 
 Skipped rounds show no outcome and do not affect scores.
+
+The `RoundHistoryRow` composable (private to `GameScreen.kt`) handles this layout.
+It receives a `RoundResult`, builds the text content, and renders the indicator + text in a `Row`.
+A thin `HorizontalDivider` (0.5 dp) separates consecutive rows for better readability.
 
 #### Header
 


### PR DESCRIPTION
## Summary

- Extracts a private `RoundHistoryRow` composable that renders each history entry as `[●]  text`
- The leading dot is colored with Material theme tokens: **green** (`primary`) for won, **red** (`error`) for lost, **grey** (`onSurfaceVariant`) for skipped — no hardcoded hex values
- A thin `HorizontalDivider` (0.5 dp, `outlineVariant`) separates consecutive rows
- Text uses `weight(1f)` + `TextOverflow.Ellipsis` to prevent layout overflow on long names or bonus lists
- Each indicator carries a `testTag` (`round_indicator_won` / `round_indicator_lost` / `round_indicator_skipped`) for UI testing

## Test plan

- [x] Unit tests pass (`./gradlew testDebugUnitTest`) — no regressions
- [x] Lint clean (`./gradlew lint`)
- [ ] Run instrumented tests on device/emulator (`./gradlew connectedAndroidTest`) — 4 new tests cover won/lost/skipped/mixed indicators

🤖 Generated with [Claude Code](https://claude.ai/claude-code)