### PR TITLE
feat(#26): add dark/light mode toggle on landing screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Android app for tracking scores in **French Tarot**, a classic French trick-t
 
 TarotCounter guides players through a game round by round:
 
-1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone
+1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap ☀️ or 🌙 in the top-left to toggle between light and dark mode (persisted across restarts, defaults to light)
 2. **Contract selection** — the current taker picks their contract (or skips)
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
 4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first; each history row shows a colored **●** indicator (green = won, red = lost, grey = skipped) for at-a-glance scanning
@@ -124,7 +124,9 @@ app/src/main/java/fr/mandarine/tarotcounter/
 |---|---|
 | `GameModelsTest.kt` | Data models, win condition, score calculation, player score distribution, `computeFinalTotals`, `findWinners` |
 | `TakerRotationTest.kt` | Taker rotation formula for 3–5 players |
-| `LandingScreenTest.kt` | Setup screen UI: player count chips, name fields, navigation, duplicate name validation |
+| `AppLocaleTest.kt` | i18n string bundles: locale-specific strings, lambda formatters, enum localized names |
+| `GameViewModelTest.kt` | ViewModel: locale + theme StateFlows, `setLocale`, `setTheme`, `saveGame`, `clearInProgressGame` |
+| `LandingScreenTest.kt` | Setup screen UI: player count chips, name fields, duplicate validation, theme toggle chips |
 | `GameScreenTest.kt` | Full game flow: contract selection, details form, history, score history navigation, End Game button |
 | `ScoreHistoryScreenTest.kt` | Score history table: column headers, cumulative totals, back navigation |
 | `FinalScoreScreenTest.kt` | Final score screen: winner card, tie detection, score table, New Game navigation |

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
@@ -36,11 +36,20 @@ class LandingScreenTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    /** Launches LandingScreen inside our app theme (same as production). */
-    private fun launch(onStartGame: (List<String>) -> Unit = {}) {
+    /**
+     * Launches LandingScreen inside our app theme (same as production).
+     * [onThemeChange] captures the AppTheme passed to the callback when a chip is tapped.
+     */
+    private fun launch(
+        onStartGame: (List<String>) -> Unit = {},
+        onThemeChange: (AppTheme) -> Unit = {}
+    ) {
         composeTestRule.setContent {
             TarotCounterTheme {
-                LandingScreen(onStartGame = onStartGame)
+                LandingScreen(
+                    onStartGame   = onStartGame,
+                    onThemeChange = onThemeChange
+                )
             }
         }
     }
@@ -300,6 +309,36 @@ class LandingScreenTest {
         launchWithPastGames()
         // The "Past Games" heading must be visible.
         composeTestRule.onNodeWithText("Past Games").assertIsDisplayed()
+    }
+
+    // ── Spec: theme toggle chips are shown ────────────────────────────────────
+
+    @Test
+    fun theme_toggle_shows_both_sun_and_moon_chips() {
+        launch()
+        // Both emoji chips must be present in the header row.
+        composeTestRule.onNodeWithText("☀️").assertIsDisplayed()
+        composeTestRule.onNodeWithText("🌙").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_moon_chip_calls_onThemeChange_with_DARK() {
+        var capturedTheme: AppTheme? = null
+        launch(onThemeChange = { capturedTheme = it })
+
+        composeTestRule.onNodeWithText("🌙").performClick()
+
+        assertEquals(AppTheme.DARK, capturedTheme)
+    }
+
+    @Test
+    fun tapping_sun_chip_calls_onThemeChange_with_LIGHT() {
+        var capturedTheme: AppTheme? = null
+        launch(onThemeChange = { capturedTheme = it })
+
+        composeTestRule.onNodeWithText("☀️").performClick()
+
+        assertEquals(AppTheme.LIGHT, capturedTheme)
     }
 
     // ── Spec: past game card shows winner name (issue #5) ─────────────────────

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppTheme.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppTheme.kt
@@ -1,0 +1,25 @@
+package fr.mandarine.tarotcounter
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+// ── Theme enum ─────────────────────────────────────────────────────────────────
+//
+// LIGHT = light mode (parchment background, dark text).
+// DARK  = dark mode  (felt-green background, light text).
+//
+// This mirrors how AppLocale.kt defines EN / FR — a simple enum that the rest
+// of the app can switch on without depending on Android's system theme APIs.
+enum class AppTheme { LIGHT, DARK }
+
+// ── CompositionLocal ──────────────────────────────────────────────────────────
+//
+// LocalAppTheme lets any composable in the tree read the current theme without
+// threading it through every function parameter.
+//
+// Usage:  val theme = LocalAppTheme.current
+//
+// `staticCompositionLocalOf` is used (same reason as LocalAppLocale): theme
+// changes always recompose the entire tree, so per-caller tracking would add
+// cost with no benefit. The default is LIGHT so Previews and tests that don't
+// provide a value still compile and render correctly.
+val LocalAppTheme = staticCompositionLocalOf { AppTheme.LIGHT }

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameStorage.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameStorage.kt
@@ -36,6 +36,9 @@ private val IN_PROGRESS_KEY = stringPreferencesKey("in_progress_game")
 // The key under which the user's chosen language is stored ("EN" or "FR").
 private val LOCALE_KEY = stringPreferencesKey("app_locale")
 
+// The key under which the user's chosen theme is stored ("LIGHT" or "DARK").
+private val THEME_KEY = stringPreferencesKey("app_theme")
+
 // How many past games to keep on the device.
 // Older games beyond this limit are dropped when a new game is saved.
 private const val MAX_SAVED_GAMES = 20
@@ -57,10 +60,12 @@ interface GameStorageInterface {
     fun loadGames(): Flow<List<SavedGame>>
     fun loadInProgressGame(): Flow<InProgressGame?>
     fun loadLocale(): Flow<AppLocale?>
+    fun loadTheme(): Flow<AppTheme?>
     suspend fun addGame(game: SavedGame)
     suspend fun saveInProgressGame(game: InProgressGame)
     suspend fun clearInProgressGame()
     suspend fun saveLocale(locale: AppLocale)
+    suspend fun saveTheme(theme: AppTheme)
 }
 
 // GameStorage handles all DataStore read and write operations for saved games.
@@ -129,6 +134,25 @@ class GameStorage(private val context: Context) : GameStorageInterface {
     override suspend fun saveLocale(locale: AppLocale) {
         context.dataStore.edit { prefs ->
             prefs[LOCALE_KEY] = locale.name
+        }
+    }
+
+    // Returns a Flow that emits the user's saved theme preference, or null if none was saved.
+    // null is interpreted as AppTheme.LIGHT by MainActivity (light mode is the default).
+    override fun loadTheme(): Flow<AppTheme?> =
+        context.dataStore.data
+            .catch { emit(emptyPreferences()) }
+            .map { prefs ->
+                // `let` applies the lambda only if the value is non-null.
+                // `runCatching` guards against unexpected stored values (e.g. old data).
+                prefs[THEME_KEY]?.let { runCatching { AppTheme.valueOf(it) }.getOrNull() }
+            }
+
+    // Persists the user's chosen theme to DataStore.
+    // `theme.name` stores the enum constant name ("LIGHT" or "DARK") as a plain string.
+    override suspend fun saveTheme(theme: AppTheme) {
+        context.dataStore.edit { prefs ->
+            prefs[THEME_KEY] = theme.name
         }
     }
 

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameViewModel.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameViewModel.kt
@@ -65,6 +65,15 @@ class GameViewModel internal constructor(
             initialValue = null
         )
 
+    // theme exposes the user's saved theme preference, or null if none has been saved yet.
+    // MainActivity resolves null → AppTheme.LIGHT (light mode is the default).
+    val theme: StateFlow<AppTheme?> = storage.loadTheme()
+        .stateIn(
+            scope        = viewModelScope,
+            started      = SharingStarted.WhileSubscribed(5_000),
+            initialValue = null
+        )
+
     // Saves the completed game to the past-games list and clears the in-progress state.
     //
     // This is called when the user presses "End Game" (not "New Game"), so the game is
@@ -103,6 +112,13 @@ class GameViewModel internal constructor(
     fun setLocale(locale: AppLocale) {
         viewModelScope.launch {
             storage.saveLocale(locale)
+        }
+    }
+
+    // Persists the user's chosen theme so it is restored on the next app launch.
+    fun setTheme(theme: AppTheme) {
+        viewModelScope.launch {
+            storage.saveTheme(theme)
         }
     }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -44,6 +44,7 @@ import java.util.Locale as JavaLocale
 
 // LandingScreen lets the user configure how many players there are and enter their names.
 // It also shows:
+//   - a theme toggle (☀️ / 🌙) in the top-left corner
 //   - a language switcher (🇬🇧 / 🇫🇷) in the top-right corner
 //   - a "Resume Game" card (if there is an unfinished game saved from a previous session)
 //   - a "Past Games" list at the bottom (if any games have been completed)
@@ -52,6 +53,7 @@ import java.util.Locale as JavaLocale
 // onResumeGame:    lambda called when the user taps "Resume" — passes the saved state back
 //                  to MainActivity so GameScreen can be initialized from it.
 // onLocaleChange:  lambda called when the user taps a flag to switch language.
+// onThemeChange:   lambda called when the user taps ☀️ or 🌙 to switch the theme.
 // inProgressGame:  a game that was interrupted mid-session, or null if there is none.
 // pastGames:       list of completed games; defaults to empty for the @Preview below.
 @Composable
@@ -61,10 +63,12 @@ fun LandingScreen(
     pastGames: List<SavedGame> = emptyList(),
     onStartGame: (List<String>) -> Unit = {},
     onResumeGame: (InProgressGame) -> Unit = {},
-    onLocaleChange: (AppLocale) -> Unit = {}
+    onLocaleChange: (AppLocale) -> Unit = {},
+    onThemeChange: (AppTheme) -> Unit = {}
 ) {
-    // Read the active locale from the composition tree and resolve all strings.
+    // Read the active locale and theme from the composition tree.
     val locale = LocalAppLocale.current
+    val theme  = LocalAppTheme.current
     val strings = appStrings(locale)
 
     // `remember` keeps a value alive across recompositions (UI redraws).
@@ -90,25 +94,41 @@ fun LandingScreen(
         verticalArrangement = Arrangement.Top
     ) {
 
-        // ── Language switcher ─────────────────────────────────────────────────
-        // Two flag chips aligned to the right edge of the screen.
-        // The chip for the active locale is shown as selected (filled background).
-        // The chips use emoji flags — these render as colour flag icons on Android.
+        // ── Header row: theme toggle (left) + language switcher (right) ──────────
+        // Both sets of chips use Material3 FilterChip — the selected chip gets a
+        // filled background; the unselected one has only an outlined border.
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End
+            horizontalArrangement = Arrangement.SpaceBetween, // push groups to each edge
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
         ) {
-            FilterChip(
-                selected = locale == AppLocale.EN,
-                onClick  = { onLocaleChange(AppLocale.EN) },
-                label    = { Text("🇬🇧") }
-            )
-            Spacer(Modifier.width(8.dp))
-            FilterChip(
-                selected = locale == AppLocale.FR,
-                onClick  = { onLocaleChange(AppLocale.FR) },
-                label    = { Text("🇫🇷") }
-            )
+            // ── Theme chips (left) ────────────────────────────────────────────
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(
+                    selected = theme == AppTheme.LIGHT,
+                    onClick  = { onThemeChange(AppTheme.LIGHT) },
+                    label    = { Text("☀️") }
+                )
+                FilterChip(
+                    selected = theme == AppTheme.DARK,
+                    onClick  = { onThemeChange(AppTheme.DARK) },
+                    label    = { Text("🌙") }
+                )
+            }
+
+            // ── Language chips (right) ────────────────────────────────────────
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                FilterChip(
+                    selected = locale == AppLocale.EN,
+                    onClick  = { onLocaleChange(AppLocale.EN) },
+                    label    = { Text("🇬🇧") }
+                )
+                FilterChip(
+                    selected = locale == AppLocale.FR,
+                    onClick  = { onLocaleChange(AppLocale.FR) },
+                    label    = { Text("🇫🇷") }
+                )
+            }
         }
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
@@ -34,35 +34,46 @@ class MainActivity : ComponentActivity() {
         // setContent replaces the traditional XML layout system.
         // Everything inside this block is Compose UI code.
         setContent {
-            // Wraps the whole app in our custom theme (colors, fonts, etc.)
-            TarotCounterTheme {
 
-                // `viewModel()` retrieves (or creates) the GameViewModel for this activity.
-                // The ViewModel survives screen rotations and is destroyed only when the
-                // activity is permanently finished (e.g. user presses the system back button).
-                val gameViewModel: GameViewModel = viewModel()
+            // `viewModel()` retrieves (or creates) the GameViewModel for this activity.
+            // The ViewModel survives screen rotations and is destroyed only when the
+            // activity is permanently finished (e.g. user presses the system back button).
+            val gameViewModel: GameViewModel = viewModel()
 
-                // `collectAsState()` subscribes to these StateFlows and converts them into
-                // Compose state. Any DataStore update automatically triggers a recomposition.
-                val pastGames      by gameViewModel.pastGames.collectAsState()
-                val inProgressGame by gameViewModel.inProgressGame.collectAsState()
-                val savedLocale    by gameViewModel.locale.collectAsState()
+            // `collectAsState()` subscribes to these StateFlows and converts them into
+            // Compose state. Any DataStore update automatically triggers a recomposition.
+            val pastGames      by gameViewModel.pastGames.collectAsState()
+            val inProgressGame by gameViewModel.inProgressGame.collectAsState()
+            val savedLocale    by gameViewModel.locale.collectAsState()
+            val savedTheme     by gameViewModel.theme.collectAsState()
 
-                // Determine the active locale:
-                //   1. If the user has explicitly chosen a language, use it.
-                //   2. Otherwise fall back to the device's system locale.
-                //   3. If the system locale is neither French nor English, default to English.
-                // `savedLocale` is null only before the first DataStore read completes
-                // (typically a few milliseconds); the system fallback prevents any flash.
-                val systemLocale = if (Locale.getDefault().language == "fr") AppLocale.FR
-                                   else AppLocale.EN
-                val currentLocale = savedLocale ?: systemLocale
+            // Determine the active locale:
+            //   1. If the user has explicitly chosen a language, use it.
+            //   2. Otherwise fall back to the device's system locale.
+            //   3. If the system locale is neither French nor English, default to English.
+            // `savedLocale` is null only before the first DataStore read completes
+            // (typically a few milliseconds); the system fallback prevents any flash.
+            val systemLocale = if (Locale.getDefault().language == "fr") AppLocale.FR
+                               else AppLocale.EN
+            val currentLocale = savedLocale ?: systemLocale
 
-                // CompositionLocalProvider makes `currentLocale` available to every
-                // composable in the tree via `LocalAppLocale.current`.
-                // Changing `currentLocale` triggers a recomposition of everything below,
-                // which instantly re-renders all strings in the new language.
-                CompositionLocalProvider(LocalAppLocale provides currentLocale) {
+            // Resolve the active theme: null means no preference saved yet → light mode.
+            // Light mode is the app default regardless of the device's system setting.
+            val currentTheme = savedTheme ?: AppTheme.LIGHT
+            val isDarkTheme  = currentTheme == AppTheme.DARK
+
+            // TarotCounterTheme wraps the entire UI with the persisted dark/light palette.
+            // It is placed outside CompositionLocalProvider so the theme's background
+            // and surface colours apply to the very first frame (no palette flash).
+            TarotCounterTheme(darkTheme = isDarkTheme) {
+
+                // CompositionLocalProvider makes both `currentLocale` and `currentTheme`
+                // available to every composable in the tree via `.current` accessors.
+                // Changing either value triggers a full recomposition of everything below.
+                CompositionLocalProvider(
+                    LocalAppLocale provides currentLocale,
+                    LocalAppTheme  provides currentTheme,
+                ) {
 
                     // Track which screen is visible. `by` delegation means we read/write
                     // `currentScreen` directly instead of `currentScreen.value`.
@@ -103,7 +114,9 @@ class MainActivity : ComponentActivity() {
                                 },
                                 // Persist the user's language choice and trigger a recomposition
                                 // through the StateFlow → collectAsState → CompositionLocalProvider chain.
-                                onLocaleChange = { gameViewModel.setLocale(it) }
+                                onLocaleChange = { gameViewModel.setLocale(it) },
+                                // Persist the user's theme choice and re-render the whole UI.
+                                onThemeChange  = { gameViewModel.setTheme(it) }
                             )
                             Screen.GAME -> GameScreen(
                                 playerNames     = confirmedPlayers,

--- a/app/src/main/java/fr/mandarine/tarotcounter/ui/theme/Theme.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package fr.mandarine.tarotcounter.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
@@ -61,7 +60,9 @@ private val LightColorScheme = lightColorScheme(
 // every colour with the user's wallpaper tones, making the custom theme useless.
 @Composable
 fun TarotCounterTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    // Default is false (light mode) — the user's system setting no longer drives this.
+    // Pass `darkTheme = true` when the user has chosen dark mode via the theme toggle.
+    darkTheme: Boolean = false,
     dynamicColor: Boolean = false, // disabled — use our card-game palette consistently
     content: @Composable () -> Unit
 ) {

--- a/app/src/test/java/fr/mandarine/tarotcounter/FakeGameStorage.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/FakeGameStorage.kt
@@ -27,6 +27,7 @@ class FakeGameStorage : GameStorageInterface {
     private val _games      = MutableStateFlow<List<SavedGame>>(emptyList())
     private val _inProgress = MutableStateFlow<InProgressGame?>(null)
     private val _locale     = MutableStateFlow<AppLocale?>(null)
+    private val _theme      = MutableStateFlow<AppTheme?>(null)
 
     // ── Call counters ─────────────────────────────────────────────────────────
     // Each counter increments every time its corresponding suspend function is called.
@@ -37,6 +38,7 @@ class FakeGameStorage : GameStorageInterface {
     var saveInProgressCallCount  = 0; private set
     var clearInProgressCallCount = 0; private set
     var saveLocaleCallCount      = 0; private set
+    var saveThemeCallCount       = 0; private set
 
     // ── Last-written values ───────────────────────────────────────────────────
     // Null means the corresponding method has never been called yet.
@@ -44,6 +46,7 @@ class FakeGameStorage : GameStorageInterface {
     var lastAddedGame:       SavedGame?      = null; private set
     var lastSavedInProgress: InProgressGame? = null; private set
     var lastSavedLocale:     AppLocale?      = null; private set
+    var lastSavedTheme:      AppTheme?       = null; private set
 
     // ── Test set-up helpers ───────────────────────────────────────────────────
     // Call these before creating the ViewModel to pre-populate the fake's state.
@@ -57,11 +60,15 @@ class FakeGameStorage : GameStorageInterface {
     /** Pre-populate the saved locale (e.g. to test locale restoration). */
     fun seedLocale(locale: AppLocale)           { _locale.value = locale }
 
+    /** Pre-populate the saved theme (e.g. to test theme restoration). */
+    fun seedTheme(theme: AppTheme)              { _theme.value = theme }
+
     // ── GameStorageInterface ──────────────────────────────────────────────────
 
     override fun loadGames():          Flow<List<SavedGame>>  = _games.asStateFlow()
     override fun loadInProgressGame(): Flow<InProgressGame?>  = _inProgress.asStateFlow()
     override fun loadLocale():         Flow<AppLocale?>       = _locale.asStateFlow()
+    override fun loadTheme():          Flow<AppTheme?>        = _theme.asStateFlow()
 
     override suspend fun addGame(game: SavedGame) {
         addGameCallCount++
@@ -85,5 +92,11 @@ class FakeGameStorage : GameStorageInterface {
         saveLocaleCallCount++
         lastSavedLocale = locale
         _locale.value = locale
+    }
+
+    override suspend fun saveTheme(theme: AppTheme) {
+        saveThemeCallCount++
+        lastSavedTheme = theme
+        _theme.value = theme
     }
 }

--- a/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
@@ -280,4 +280,59 @@ class GameViewModelTest {
         assertEquals(AppLocale.EN, collected.last())
         job.cancel()
     }
+
+    // ── setTheme ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `setTheme DARK delegates to saveTheme with the correct theme`() = runTest {
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+
+        vm.setTheme(AppTheme.DARK)
+
+        assertEquals(1, storage.saveThemeCallCount)
+        assertEquals(AppTheme.DARK, storage.lastSavedTheme)
+    }
+
+    @Test
+    fun `setTheme LIGHT delegates to saveTheme with the correct theme`() = runTest {
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+
+        vm.setTheme(AppTheme.LIGHT)
+
+        assertEquals(AppTheme.LIGHT, storage.lastSavedTheme)
+    }
+
+    @Test
+    fun `theme initial value is null`() {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        assertNull(vm.theme.value)
+    }
+
+    @Test
+    fun `theme StateFlow reflects theme seeded before ViewModel is created`() = runTest {
+        val storage = FakeGameStorage().also { it.seedTheme(AppTheme.DARK) }
+        val vm = GameViewModel(Application(), storage)
+
+        val collected = mutableListOf<AppTheme?>()
+        val job = launch(testDispatcher) { vm.theme.collect { collected.add(it) } }
+
+        assertEquals(AppTheme.DARK, collected.last())
+        job.cancel()
+    }
+
+    @Test
+    fun `theme StateFlow updates after setTheme is called`() = runTest {
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+
+        val collected = mutableListOf<AppTheme?>()
+        val job = launch(testDispatcher) { vm.theme.collect { collected.add(it) } }
+
+        vm.setTheme(AppTheme.DARK)
+
+        assertEquals(AppTheme.DARK, collected.last())
+        job.cancel()
+    }
 }

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -45,3 +45,32 @@ The `dynamicColor` parameter of `TarotCounterTheme` defaults to `false`. This me
 - The custom green/gold palette is used on **all Android versions**.
 - On Android 12+, the OS would normally replace the entire palette with colours derived from the user's wallpaper. Disabling this ensures the card-game aesthetic is always present.
 - The parameter is kept in the function signature so it can still be set to `true` in tests if needed.
+
+## Dark / Light Mode Toggle
+
+The app provides a manual theme toggle so the user can override the system setting.
+
+### Default
+
+Light mode (`darkTheme = false`) is **always** the default — the system dark-mode preference is intentionally ignored. The `TarotCounterTheme` parameter default was changed from `isSystemInDarkTheme()` to `false` as part of this feature.
+
+### UI
+
+Two `FilterChip`s — ☀️ (light) and 🌙 (dark) — appear in the **top-left** corner of the Landing Screen, mirroring the 🇬🇧 / 🇫🇷 language chips on the right. The selected chip has a filled background; the other is unselected (outlined).
+
+### Persistence
+
+The choice is stored in DataStore using `THEME_KEY = stringPreferencesKey("app_theme")` (the string `"LIGHT"` or `"DARK"`). It is loaded on startup and applied before the first frame via `TarotCounterTheme(darkTheme = isDarkTheme)`.
+
+### Architecture
+
+Follows the same pattern as locale switching:
+
+| Layer | Component |
+|---|---|
+| Model | `AppTheme` enum (`LIGHT`, `DARK`) in `AppTheme.kt` |
+| Storage | `THEME_KEY`, `loadTheme()`, `saveTheme()` in `GameStorage.kt` |
+| ViewModel | `theme: StateFlow<AppTheme?>`, `setTheme()` in `GameViewModel.kt` |
+| Composition | `LocalAppTheme` in `AppTheme.kt` (read via `LocalAppTheme.current`) |
+| UI | `TarotCounterTheme(darkTheme = isDarkTheme)` in `MainActivity.kt` |
+| Toggle | ☀️ / 🌙 `FilterChip`s in `LandingScreen.kt` |


### PR DESCRIPTION
## Summary

- Adds `AppTheme` enum (`LIGHT`/`DARK`) and `LocalAppTheme` CompositionLocal in `AppTheme.kt`, following the same pattern as `AppLocale`
- Adds `THEME_KEY`, `loadTheme()`, and `saveTheme()` to `GameStorageInterface` and `GameStorage` for DataStore persistence
- Adds `theme: StateFlow<AppTheme?>` and `setTheme()` to `GameViewModel`
- Changes `TarotCounterTheme` default from `isSystemInDarkTheme()` to `false` — light mode is always the default
- Wires everything through `MainActivity`: collects theme, resolves `null → AppTheme.LIGHT`, passes `isDarkTheme` to `TarotCounterTheme`, provides `LocalAppTheme`
- Adds ☀️ / 🌙 `FilterChip`s to the **top-left** of the `LandingScreen` header row, symmetrical to the 🇬🇧 / 🇫🇷 chips on the right

## Test plan

- [x] `GameViewModelTest` — `setTheme`, `theme` StateFlow initial value, seeded value, updates
- [x] `LandingScreenTest` — both chips displayed, tapping 🌙 calls `onThemeChange(DARK)`, tapping ☀️ calls `onThemeChange(LIGHT)`
- [x] `./gradlew testDebugUnitTest` — all pass
- [x] `./gradlew lint` — clean

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)