### PR TITLE
feat(#31): move Start button below player name fields

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
@@ -154,25 +154,25 @@ class LandingScreenTest {
         composeTestRule.onNodeWithText("Start Game").assertIsDisplayed()
     }
 
-    // The button must appear ABOVE the name input fields so it stays visible
-    // when the on-screen keyboard is open (issue #19).
+    // The button must appear BELOW the name input fields so the visual flow
+    // guides the user: enter names first, then press Start (issue #31).
     @Test
-    fun start_game_button_is_above_player_name_fields() {
+    fun start_game_button_is_below_player_name_fields() {
         launch()
         // getBoundsInRoot() returns the position of each node on screen.
-        // We compare the bottom edge of the button with the top edge of the
-        // first name field: button.bottom must be less than field.top.
+        // We compare the top edge of the button with the bottom edge of the
+        // last name field: button.top must be greater than field.bottom.
         val buttonBounds = composeTestRule
             .onNodeWithText("Start Game")
             .getBoundsInRoot()
         val fieldBounds = composeTestRule
-            .onNodeWithText("Player 1")
+            .onNodeWithText("Player 3")
             .getBoundsInRoot()
 
-        // The button's bottom edge should be above the first name-field's top edge.
-        assert(buttonBounds.bottom < fieldBounds.top) {
-            "Expected Start Game button (bottom=${buttonBounds.bottom}) to be above " +
-                "Player 1 field (top=${fieldBounds.top})"
+        // The button's top edge should be below the last name-field's bottom edge.
+        assert(buttonBounds.top > fieldBounds.bottom) {
+            "Expected Start Game button (top=${buttonBounds.top}) to be below " +
+                "Player 3 field (bottom=${fieldBounds.bottom})"
         }
     }
 

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -213,21 +213,6 @@ fun LandingScreen(
         // The button is disabled and a warning is shown whenever any duplicate exists.
         val hasDuplicates = duplicateFlags.any { it }
 
-        // "Start Game" button placed ABOVE the name fields so it stays visible when the
-        // on-screen keyboard is open. The user can start immediately (names fall back to
-        // "Player N") or fill the fields first — either way the button is reachable
-        // without closing the keyboard.
-        // `enabled = !hasDuplicates` prevents starting a game when names clash.
-        Button(
-            onClick = { onStartGame(playerNames.toList()) },
-            enabled = !hasDuplicates,
-            modifier = Modifier.fillMaxWidth(0.8f)
-        ) {
-            Text(strings.startGame)
-        }
-
-        Spacer(modifier = Modifier.height(24.dp))
-
         Text(
             text = strings.playerNamesLabel,
             style = MaterialTheme.typography.titleMedium
@@ -253,6 +238,19 @@ fun LandingScreen(
                     .fillMaxWidth(0.8f)                   // 80% of screen width
                     .padding(vertical = 4.dp)
             )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // "Start Game" button placed BELOW the name fields so the visual flow naturally
+        // guides the user: enter names first, then press Start.
+        // `enabled = !hasDuplicates` prevents starting a game when names clash.
+        Button(
+            onClick = { onStartGame(playerNames.toList()) },
+            enabled = !hasDuplicates,
+            modifier = Modifier.fillMaxWidth(0.8f)
+        ) {
+            Text(strings.startGame)
         }
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/docs/player-setup.md
+++ b/docs/player-setup.md
@@ -9,14 +9,14 @@ The landing screen lets users configure a game before it starts. It currently ha
 
 ## Layout
 
-The screen uses a scrollable `Column`. To keep the "Start Game" button reachable even when the on-screen keyboard is open, the button is placed **above** the name input fields. The layout order is:
+The screen uses a scrollable `Column`. The layout order follows the natural user flow — configure players, enter names, then start:
 
 1. Language switcher (flag chips, top-right)
 2. Card-suit decorative header (`♠ ♥ ♦ ♣`, in primary color)
 3. App title
 4. Player count chips (3 / 4 / 5)
-5. **Start Game button** ← always visible above the keyboard
-6. Player name fields
+5. Player name fields
+6. **Start Game button** ← below the name fields
 7. Resume Game card (if an unfinished game is saved)
 8. Past Games list (if any completed games exist)
 


### PR DESCRIPTION
## Summary

- Moves the **Start Game** button from above the player name fields to below them
- The visual flow now naturally guides the user: choose player count → enter names → press Start
- Updates the position assertion in `LandingScreenTest` (`is_above` → `is_below`)
- Updates `docs/player-setup.md` to reflect the new layout order

Closes #31