### PR TITLE
fix(#33): prevent Attaquant/Défenseurs toggle labels from wrapping

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -423,7 +423,12 @@ fun GameScreen(
                                         pointsText   = ""  // clear field when switching camps
                                     },
                                     shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
-                                ) { Text(strings.attackerMode) }
+                                ) {
+                                    // maxLines = 1 and softWrap = false together prevent the label from
+                                    // ever breaking onto a second line, regardless of screen width.
+                                    // This fixes the French "Défenseurs" wrapping bug on narrow screens.
+                                    Text(strings.attackerMode, maxLines = 1, softWrap = false)
+                                }
                                 SegmentedButton(
                                     selected = defenderMode,
                                     onClick  = {
@@ -431,7 +436,9 @@ fun GameScreen(
                                         pointsText   = ""  // clear field when switching camps
                                     },
                                     shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
-                                ) { Text(strings.defenderMode) }
+                                ) {
+                                    Text(strings.defenderMode, maxLines = 1, softWrap = false)
+                                }
                             }
                             OutlinedTextField(
                                 value = pointsText,


### PR DESCRIPTION
## Summary

- Adds `maxLines = 1` and `softWrap = false` to the `Text` composables inside both `SegmentedButton`s (Attaquant / Défenseurs toggle)
- Prevents the trailing "s" of "Défenseurs" from wrapping to a new line on narrow screens in French locale

## Root cause

`Text` in Compose allows soft word-wrapping by default. On narrow screens, the French label "Défenseurs" (10 chars) didn't fit in the half-width button alongside the selection checkmark icon, causing a line break.

## Fix

`softWrap = false` disables word-wrapping entirely at the layout level; `maxLines = 1` is the belt-and-suspenders guard. Together they guarantee the label stays on one line at any screen width.

## Test plan

- [ ] Build and run on a narrow device/emulator (360 dp or less) with language set to French
- [ ] Verify "Attaquant" and "Défenseurs" both display on a single line
- [ ] Verify English labels ("Attacker" / "Defenders") still display correctly
- [ ] Unit tests pass: `./gradlew testDebugUnitTest`

Closes #33