### PR TITLE
feat(#38): handle Android back button to navigate to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ TarotCounter guides players through a game round by round:
 5. **Score history table** — tap the bar-chart icon (left of the header) to see a round-by-round table of cumulative scores for every player
 6. **End Game / Final Score** — tap **End Game** in the bottom bar at any point to see the final results: winner card with total score, full round-by-round table (winner's column highlighted in gold/amber), and a "New Game" button
 7. **Colour-coded scores** — positive scores appear in green and negative scores in red across all score views (CompactScoreboard, ScoreHistoryScreen, FinalScoreScreen); colours adapt to light/dark theme automatically
-7. **Auto-save & Resume** — the game state is saved after every round; if the app is closed mid-game, a "Resume Game" card appears on the setup screen the next time it is opened
-8. **Past Games** — completed games are saved to the device; the setup screen shows a list of past results with a trophy icon next to the winner's name
+8. **Auto-save & Resume** — the game state is saved after every round; if the app is closed mid-game, a "Resume Game" card appears on the setup screen the next time it is opened
+9. **Past Games** — completed games are saved to the device; the setup screen shows a list of past results with a trophy icon next to the winner's name
+10. **Back navigation** — the Android system back button always returns to the landing page; on the Final Score screen a confirmation dialog is shown first to avoid accidentally losing unsaved results
 
 The app automatically rotates the taker each round, determines win/loss, and computes each player's score for the round.
 
@@ -166,3 +167,4 @@ More detailed documentation lives in [`docs/`](docs/):
 - [`docs/game-persistence.md`](docs/game-persistence.md) — how completed games are saved to DataStore and displayed on the setup screen
 - [`docs/score-color.md`](docs/score-color.md) — score colour-coding convention: `scoreColor()` helper, where it is used, winner column
 - [`docs/theme.md`](docs/theme.md) — colour palette rationale, roles, and dynamic-colour policy
+- [`docs/back-navigation.md`](docs/back-navigation.md) — system back button behaviour per screen, BackHandler implementation, confirmation dialog

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/FinalScoreScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/FinalScoreScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
 import org.junit.Assert.assertTrue
@@ -26,6 +27,9 @@ import org.junit.runner.RunWith
  *   - Winner's column is highlighted (bold) in the table
  *   - Shows "No rounds played" when the history is empty
  *   - "New Game" button fires the onNewGame callback
+ *   - System back button shows a confirmation dialog (issue #38)
+ *   - Confirming the dialog fires onNewGame (navigates to landing)
+ *   - Cancelling the dialog dismisses it without navigating
  */
 @RunWith(AndroidJUnit4::class)
 class FinalScoreScreenTest {
@@ -306,5 +310,53 @@ class FinalScoreScreenTest {
         launchFinal(onNewGame = { callbackFired = true })
         composeTestRule.onNodeWithText("New Game").performClick()
         assertTrue("onNewGame callback should have been called", callbackFired)
+    }
+
+    // ── Spec: system back-button (issue #38) ─────────────────────────────────
+    // The Android system back button should NOT exit the app or return to the game
+    // immediately. Instead it shows a confirmation dialog so the user can decide
+    // whether to leave (losing unsaved results) or stay.
+
+    @Test
+    fun pressing_system_back_shows_leave_confirmation_dialog() {
+        // Spec: back on Final Score → dialog with "Leave the game?" title.
+        launchFinal()
+        // Espresso.pressBack() simulates the system back button / back gesture.
+        // BackHandler intercepts it and sets showLeaveConfirm = true.
+        Espresso.pressBack()
+        composeTestRule.onNodeWithText("Leave the game?").assertIsDisplayed()
+    }
+
+    @Test
+    fun leave_confirmation_dialog_shows_body_text() {
+        // Spec: the dialog body warns that results won't be saved.
+        launchFinal()
+        Espresso.pressBack()
+        composeTestRule
+            .onNodeWithText("The game results won't be saved if you leave now.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun confirming_leave_dialog_fires_onNewGame_callback() {
+        // Spec: tapping "Leave" in the dialog navigates to the landing page.
+        var newGameCalled = false
+        launchFinal(onNewGame = { newGameCalled = true })
+        Espresso.pressBack()
+        composeTestRule.onNodeWithText("Leave").performClick()
+        assertTrue("Confirming the dialog should fire onNewGame", newGameCalled)
+    }
+
+    @Test
+    fun cancelling_leave_dialog_dismisses_it_without_navigating() {
+        // Spec: tapping "Cancel" closes the dialog; the Final Score screen stays.
+        var newGameCalled = false
+        launchFinal(onNewGame = { newGameCalled = true })
+        Espresso.pressBack()
+        composeTestRule.onNodeWithText("Cancel").performClick()
+        // Dialog should be gone and Game Over screen still visible.
+        composeTestRule.onNodeWithText("Leave the game?").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Game Over").assertIsDisplayed()
+        assertTrue("Cancelling should NOT fire onNewGame", !newGameCalled)
     }
 }

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
 import org.junit.Assert.assertTrue
@@ -572,4 +573,46 @@ class GameScreenTest {
         composeTestRule.onNodeWithTag("round_indicator_skipped").assertIsDisplayed()
         composeTestRule.onNodeWithTag("round_indicator_lost").assertIsDisplayed()
     }
-}
+
+    // ── Spec: system back-button on game screen (issue #38) ───────────────────
+    // Pressing the Android system back button on the main game view (no overlay)
+    // should navigate directly to the landing page — no confirmation dialog.
+
+    @Test
+    fun pressing_system_back_on_game_screen_fires_onEndGame_callback() {
+        // Spec: back on the game screen → landing page (no dialog, immediate navigation).
+        var endGameCalled = false
+        composeTestRule.setContent {
+            TarotCounterTheme {
+                // Wire onEndGame so we can verify the callback is called.
+                GameScreen(
+                    playerNames = players,
+                    onEndGame   = { endGameCalled = true }
+                )
+            }
+        }
+        // Espresso.pressBack() triggers the system back button.
+        // BackHandler (enabled = !showFinalScore, which starts as false) intercepts it.
+        Espresso.pressBack()
+        assertTrue("System back on game screen should call onEndGame", endGameCalled)
+    }
+
+    @Test
+    fun pressing_system_back_on_history_overlay_fires_onEndGame_callback() {
+        // Spec: back on the score-history overlay → landing page (no dialog).
+        var endGameCalled = false
+        composeTestRule.setContent {
+            TarotCounterTheme {
+                GameScreen(
+                    playerNames = players,
+                    onEndGame   = { endGameCalled = true }
+                )
+            }
+        }
+        // Open the history overlay by tapping the "History" button.
+        composeTestRule.onNodeWithText("History").performClick()
+        // Back should still go to landing page, not back to game screen.
+        Espresso.pressBack()
+        assertTrue("System back on history overlay should call onEndGame", endGameCalled)
+    }
+}}

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
@@ -131,6 +131,14 @@ data class AppStrings(
     // "Round" / "Manche" column header in the score table.
     val roundColumn: String,
 
+    // ── Back-navigation confirmation dialog (Final Score screen) ──────────────
+    // Shown when the user presses the system back button on the Final Score screen.
+    // The body warns that leaving will discard unsaved results.
+    val backConfirmTitle: String,
+    val backConfirmBody: String,
+    // Confirm action label — distinct from `cancel` which already exists.
+    val backConfirmLeave: String,
+
     // ── Chelem enum labels ────────────────────────────────────────────────────
     val chelemNone: String,
     val chelemAnnouncedRealized: String,
@@ -204,6 +212,10 @@ val EnStrings = AppStrings(
     scoreHistory          = "Score history",
     roundColumn           = "Round",
 
+    backConfirmTitle      = "Leave the game?",
+    backConfirmBody       = "The game results won't be saved if you leave now.",
+    backConfirmLeave      = "Leave",
+
     chelemNone               = "None",
     chelemAnnouncedRealized  = "Announced & realized",
     chelemAnnouncedNotRealized = "Announced, not realized",
@@ -275,6 +287,10 @@ val FrStrings = AppStrings(
 
     scoreHistory          = "Historique des scores",
     roundColumn           = "Manche",
+
+    backConfirmTitle      = "Quitter la partie ?",
+    backConfirmBody       = "Les résultats ne seront pas sauvegardés si vous quittez maintenant.",
+    backConfirmLeave      = "Quitter",
 
     chelemNone               = "Aucun",
     chelemAnnouncedRealized  = "Annoncé et réalisé",

--- a/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
@@ -1,5 +1,6 @@
 package fr.mandarine.tarotcounter
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
@@ -22,6 +23,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -30,6 +32,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -82,6 +85,41 @@ fun FinalScoreScreen(
 ) {
     // Read the active locale and resolve all strings once at the top of the composable.
     val strings = appStrings(LocalAppLocale.current)
+
+    // ── System back-button handling ───────────────────────────────────────────
+    // Controls whether the leave-confirmation dialog is visible.
+    // The dialog is triggered by the system back button (or gesture), not by the
+    // in-screen back arrow — the arrow stays wired to onBack (return to game).
+    var showLeaveConfirm by remember { mutableStateOf(false) }
+
+    // BackHandler intercepts the Android system back button while this composable
+    // is in the composition. Because FinalScoreScreen is placed *after* the
+    // GameScreen-level BackHandler in the composition tree, this one takes priority
+    // and GameScreen's handler is effectively shadowed.
+    BackHandler { showLeaveConfirm = true }
+
+    // Confirmation dialog — only rendered when showLeaveConfirm is true.
+    // AlertDialog is a Material 3 modal that blocks interaction with the rest of
+    // the screen until the user picks "Leave" or "Cancel".
+    if (showLeaveConfirm) {
+        AlertDialog(
+            onDismissRequest = { showLeaveConfirm = false },
+            title = { Text(strings.backConfirmTitle) },
+            text  = { Text(strings.backConfirmBody) },
+            confirmButton = {
+                // "Leave" navigates to the landing page (same as "New Game" button).
+                TextButton(onClick = onNewGame) {
+                    Text(strings.backConfirmLeave)
+                }
+            },
+            dismissButton = {
+                // "Cancel" closes the dialog and returns to the Final Score screen.
+                TextButton(onClick = { showLeaveConfirm = false }) {
+                    Text(strings.cancel)
+                }
+            }
+        )
+    }
 
     // `computeFinalTotals` sums each player's per-round scores across all rounds.
     // It lives in GameModels so it can be unit-tested without Compose.

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -1,5 +1,6 @@
 package fr.mandarine.tarotcounter
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -183,6 +184,17 @@ fun GameScreen(
         }
         showFinalScore = true
     }
+
+    // ── System back-button handling ───────────────────────────────────────────
+    // BackHandler intercepts the Android system back button (gesture or hardware key).
+    //
+    // A single handler covers both the main game view and the score-history overlay:
+    // pressing back on either navigates directly to the landing page (no dialog).
+    //
+    // `enabled = !showFinalScore` disables this handler when the Final Score screen
+    // is visible — that composable registers its own BackHandler (deeper in the
+    // Compose tree, therefore higher priority) which shows a confirmation dialog first.
+    BackHandler(enabled = !showFinalScore) { onEndGame() }
 
     // ── Overlay screens ───────────────────────────────────────────────────────
     // These replace the whole content when active. The main game column is not rendered.

--- a/docs/back-navigation.md
+++ b/docs/back-navigation.md
@@ -1,0 +1,60 @@
+# Back Navigation
+
+## Overview
+
+The Android system back button (hardware key or gesture swipe) is handled consistently across all screens. The destination is always the **landing page** — there is no intermediate back stack.
+
+## Behaviour by screen
+
+| Screen | System back button |
+|---|---|
+| Game screen | Navigate directly to landing page (no dialog) |
+| Score history overlay | Navigate directly to landing page (no dialog) |
+| Final Score screen | Show a confirmation dialog first |
+
+The **back arrow** in the screen header is a separate affordance and is unaffected: it continues to navigate one level up within the game flow (e.g. history → game, final score → game).
+
+## Implementation
+
+Back interception uses `BackHandler` from `androidx.activity.compose`. A `BackHandler` is a composable that registers a callback with the activity's `OnBackPressedDispatcher`. The most recently composed enabled handler wins, which makes the overlay pattern work naturally.
+
+### Game screen and history overlay
+
+A single `BackHandler` in `GameScreen.kt` covers both the main game view and the score-history overlay:
+
+```kotlin
+// Disabled when Final Score is showing — that screen handles back itself.
+BackHandler(enabled = !showFinalScore) { onEndGame() }
+```
+
+When `showScoreHistory` is true (history overlay is visible), this handler still fires and calls `onEndGame()`, which navigates to the landing page.
+
+### Final Score screen
+
+`FinalScoreScreen.kt` registers its own `BackHandler` (deeper in the composition tree, so higher priority). It sets a boolean flag to show a Material 3 `AlertDialog`:
+
+```kotlin
+var showLeaveConfirm by remember { mutableStateOf(false) }
+BackHandler { showLeaveConfirm = true }
+
+if (showLeaveConfirm) {
+    AlertDialog(
+        title = { Text(strings.backConfirmTitle) },
+        text  = { Text(strings.backConfirmBody) },
+        confirmButton = { TextButton(onClick = onNewGame) { Text(strings.backConfirmLeave) } },
+        dismissButton = { TextButton(onClick = { showLeaveConfirm = false }) { Text(strings.cancel) } }
+    )
+}
+```
+
+Tapping **Leave** fires `onNewGame` (navigates to landing page). Tapping **Cancel** closes the dialog and stays on the Final Score screen.
+
+## Localisation
+
+The dialog strings are defined in `AppLocale.kt` for both locales:
+
+| Key | English | French |
+|---|---|---|
+| `backConfirmTitle` | Leave the game? | Quitter la partie ? |
+| `backConfirmBody` | The game results won't be saved if you leave now. | Les résultats ne seront pas sauvegardés si vous quittez maintenant. |
+| `backConfirmLeave` | Leave | Quitter |


### PR DESCRIPTION
## Summary

- **Game screen & history overlay**: a single `BackHandler(enabled = !showFinalScore)` in `GameScreen.kt` intercepts the system back button and calls `onEndGame()` directly — no confirmation needed for either view.
- **Final Score screen**: `FinalScoreScreen.kt` registers its own `BackHandler` (deeper in the composition tree, so higher priority). It shows a Material 3 `AlertDialog` asking "Leave the game?"; tapping **Leave** fires `onNewGame` (→ landing page), tapping **Cancel** dismisses the dialog and stays on the screen.
- New localized strings (`backConfirmTitle`, `backConfirmBody`, `backConfirmLeave`) added in EN and FR to `AppLocale.kt`.

## Test plan

- [ ] `FinalScoreScreenTest` — `pressing_system_back_shows_leave_confirmation_dialog` verifies the dialog appears
- [ ] `FinalScoreScreenTest` — `confirming_leave_dialog_fires_onNewGame_callback` verifies navigation
- [ ] `FinalScoreScreenTest` — `cancelling_leave_dialog_dismisses_it_without_navigating` verifies cancel stays on screen
- [ ] `GameScreenTest` — `pressing_system_back_on_game_screen_fires_onEndGame_callback`
- [ ] `GameScreenTest` — `pressing_system_back_on_history_overlay_fires_onEndGame_callback`
- [ ] Run `./gradlew connectedAndroidTest` on a device/emulator to validate all instrumented tests
- [ ] Manual: verify back gesture on each screen behaves as specified in the issue table