### PR TITLE
feat(#40): set proper app name with French locale support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Android app for tracking scores in **French Tarot**, a classic French trick-t
 
 TarotCounter guides players through a game round by round:
 
-1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap ☀️ or 🌙 in the top-left to toggle between light and dark mode (persisted across restarts, defaults to light)
+1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap ☀️ or 🌙 in the top-left to toggle between light and dark mode (persisted across restarts, defaults to light); tap 🇬🇧 or 🇫🇷 in the top-right to switch the app language (persisted across restarts, defaults to device language)
 2. **Contract selection** — the current taker picks their contract; a persistent **bottom action bar** always shows **End Game** (left) and **Skip round** (right) for quick access
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
 4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first; each history row shows a colored **●** indicator (green = won, red = lost, grey = skipped) for at-a-glance scanning
@@ -149,7 +149,8 @@ TarotCounter/
 │   ├── final-score.md        # Final score screen: winner card, End Game flow
 │   ├── game-persistence.md   # How completed games are saved and displayed
 │   ├── score-color.md        # Score colour-coding convention and scoreColor() helper
-│   └── theme.md              # Colour palette rationale and dynamic-colour policy
+│   ├── theme.md              # Colour palette rationale and dynamic-colour policy
+│   └── app-name.md           # App name branding and locale-specific launcher labels
 ├── gradle/
 │   └── libs.versions.toml  # Dependency version catalog
 ├── CLAUDE.md               # AI assistant instructions
@@ -168,3 +169,4 @@ More detailed documentation lives in [`docs/`](docs/):
 - [`docs/score-color.md`](docs/score-color.md) — score colour-coding convention: `scoreColor()` helper, where it is used, winner column
 - [`docs/theme.md`](docs/theme.md) — colour palette rationale, roles, and dynamic-colour policy
 - [`docs/back-navigation.md`](docs/back-navigation.md) — system back button behaviour per screen, BackHandler implementation, confirmation dialog
+- [`docs/app-name.md`](docs/app-name.md) — app name branding, locale-specific launcher labels, and how the system name and in-app title relate

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.TarotCounter">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--
+        App name shown by the Android system (launcher icon, recent apps, Settings → Apps)
+        when the device language is French.
+        Matches the in-app French title defined in AppLocale.kt (FrStrings.appTitle = "Tarot").
+    -->
+    <string name="app_name">Tarot</string>
+</resources>

--- a/docs/app-name.md
+++ b/docs/app-name.md
@@ -1,0 +1,38 @@
+# App Name & Branding
+
+## System App Name
+
+The name shown by the Android system (launcher icon, recent-apps screen, Settings → Apps) is
+defined in the XML string resource `app_name`, referenced by `android:label` in
+`AndroidManifest.xml`.
+
+| Device language | Displayed name | Resource file |
+|---|---|---|
+| English (default) | Tarot Counter | `res/values/strings.xml` |
+| French | Tarot | `res/values-fr/strings.xml` |
+
+The French variant "Tarot" matches the in-app French title (`FrStrings.appTitle` in `AppLocale.kt`).
+
+## In-App Title
+
+The title shown inside the app (on the landing screen) comes from the `AppStrings.appTitle` field,
+resolved at runtime via the `CompositionLocal`-based i18n system in `AppLocale.kt`:
+
+| Locale | Title |
+|---|---|
+| `AppLocale.EN` | "Tarot Counter" |
+| `AppLocale.FR` | "Tarot" |
+
+The user can switch language at any time using the 🇬🇧 / 🇫🇷 flag chips on the landing screen.
+The choice is persisted via DataStore and restored on next launch. If no preference is saved,
+the app falls back to the device's system language.
+
+## How the Two Systems Work Together
+
+- The **system app name** (from `strings.xml`) is picked by Android based on the device language
+  at install time (or when the device language changes). It cannot be changed by the app at runtime.
+- The **in-app title** (from `AppLocale.kt`) follows the user's explicit in-app language choice,
+  which may differ from the device language.
+
+Both systems use the same naming convention so they stay consistent when the device language and
+in-app language match.


### PR DESCRIPTION
## Summary

- `values/strings.xml` already had `app_name = "Tarot Counter"` (set in the init commit); this PR confirms and completes the fix
- Adds `values-fr/strings.xml` with `app_name = "Tarot"` so Android shows the correct label in the launcher / recent apps / Settings when the device language is French — consistent with `FrStrings.appTitle` in `AppLocale.kt`
- Removes the redundant `android:label` from the `<activity>` element in `AndroidManifest.xml` (the application-level label already covers it; an activity label is only needed when it should differ from the app label)
- Adds `docs/app-name.md` documenting the two-layer naming system (system resource vs. in-app `CompositionLocal`)
- Updates README: adds the 🇬🇧/🇫🇷 language-switcher to the feature list and references the new doc

## Test plan

- [x] `./gradlew testDebugUnitTest` — all unit tests pass
- [x] `./gradlew lint` — no new warnings
- [ ] Manual: install on an English device → launcher shows **Tarot Counter**
- [ ] Manual: install on a French device (or change device language to French) → launcher shows **Tarot**

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)