### PR TITLE
feat(#41): configure release signing in build.gradle.kts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Keystore files — never commit signing keys to source control
+*.jks
+*.keystore

--- a/README.md
+++ b/README.md
@@ -99,12 +99,29 @@ app/src/main/java/fr/mandarine/tarotcounter/
 # Build debug APK
 ./gradlew assembleDebug
 
-# Build release APK
+# Build release APK (unsigned — no credentials configured)
 ./gradlew assembleRelease
+
+# Build signed release bundle for Google Play (requires signing credentials)
+./gradlew bundleRelease
 
 # Install on connected device
 ./gradlew installDebug
 ```
+
+### Release Signing
+
+`./gradlew bundleRelease` produces a signed `.aab` when the following credentials
+are supplied via `~/.gradle/gradle.properties` (local) or environment variables (CI):
+
+| Variable | Description |
+|---|---|
+| `RELEASE_KEYSTORE_FILE` | Path to the `.jks` keystore |
+| `RELEASE_KEYSTORE_PASSWORD` | Keystore password |
+| `RELEASE_KEY_ALIAS` | Key alias |
+| `RELEASE_KEY_PASSWORD` | Key password |
+
+See [`docs/release-signing.md`](docs/release-signing.md) for full setup instructions.
 
 ## Testing
 
@@ -150,7 +167,8 @@ TarotCounter/
 │   ├── game-persistence.md   # How completed games are saved and displayed
 │   ├── score-color.md        # Score colour-coding convention and scoreColor() helper
 │   ├── theme.md              # Colour palette rationale and dynamic-colour policy
-│   └── app-name.md           # App name branding and locale-specific launcher labels
+│   ├── app-name.md           # App name branding and locale-specific launcher labels
+│   └── release-signing.md    # Release signing setup for local dev and CI
 ├── gradle/
 │   └── libs.versions.toml  # Dependency version catalog
 ├── CLAUDE.md               # AI assistant instructions
@@ -170,3 +188,4 @@ More detailed documentation lives in [`docs/`](docs/):
 - [`docs/theme.md`](docs/theme.md) — colour palette rationale, roles, and dynamic-colour policy
 - [`docs/back-navigation.md`](docs/back-navigation.md) — system back button behaviour per screen, BackHandler implementation, confirmation dialog
 - [`docs/app-name.md`](docs/app-name.md) — app name branding, locale-specific launcher labels, and how the system name and in-app title relate
+- [`docs/release-signing.md`](docs/release-signing.md) — how to configure release signing for local builds and CI/CD pipelines

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,33 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+// ── Release signing credentials ───────────────────────────────────────────────
+// Read from gradle.properties (local or ~/.gradle/gradle.properties) first,
+// then fall back to environment variables so CI pipelines can inject secrets
+// without touching any file on disk.
+// All four values must be present for the signing config to be registered;
+// if any is missing the release build is produced unsigned (safe for local dev).
+val releaseKeystoreFile: String? =
+    findProperty("RELEASE_KEYSTORE_FILE")?.toString()
+        ?: System.getenv("RELEASE_KEYSTORE_FILE")
+val releaseKeystorePassword: String? =
+    findProperty("RELEASE_KEYSTORE_PASSWORD")?.toString()
+        ?: System.getenv("RELEASE_KEYSTORE_PASSWORD")
+val releaseKeyAlias: String? =
+    findProperty("RELEASE_KEY_ALIAS")?.toString()
+        ?: System.getenv("RELEASE_KEY_ALIAS")
+val releaseKeyPassword: String? =
+    findProperty("RELEASE_KEY_PASSWORD")?.toString()
+        ?: System.getenv("RELEASE_KEY_PASSWORD")
+
+// True only when every credential is available.
+val hasSigningConfig = listOf(
+    releaseKeystoreFile,
+    releaseKeystorePassword,
+    releaseKeyAlias,
+    releaseKeyPassword,
+).none { it.isNullOrBlank() }
+
 android {
     namespace = "fr.mandarine.tarotcounter"
     compileSdk {
@@ -23,8 +50,27 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    // ── Signing configs ───────────────────────────────────────────────────────
+    // Only registered when all four credentials are present (see top of file).
+    // The "release" config is named so that buildTypes.release can reference it
+    // by name via signingConfigs.getByName("release").
+    if (hasSigningConfig) {
+        signingConfigs {
+            create("release") {
+                // file() resolves the path relative to the module directory (app/).
+                storeFile = file(releaseKeystoreFile!!)
+                storePassword = releaseKeystorePassword!!
+                keyAlias = releaseKeyAlias!!
+                keyPassword = releaseKeyPassword!!
+            }
+        }
+    }
+
     buildTypes {
         release {
+            // Wire the signing config when credentials were provided; otherwise
+            // the artifact is left unsigned (you must sign it manually before upload).
+            signingConfig = signingConfigs.findByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,99 @@
+# Release Signing
+
+Android apps must be signed with a private key before they can be published to Google Play.
+This document explains how the signing configuration works and how to set it up.
+
+## How It Works
+
+`app/build.gradle.kts` reads four credentials at configuration time:
+
+| Property name | What it holds |
+|---|---|
+| `RELEASE_KEYSTORE_FILE` | Path to the `.jks` keystore file (relative to `app/` or absolute) |
+| `RELEASE_KEYSTORE_PASSWORD` | Password protecting the keystore file |
+| `RELEASE_KEY_ALIAS` | Alias of the signing key inside the keystore |
+| `RELEASE_KEY_PASSWORD` | Password protecting that specific key |
+
+The build script first looks for each value in **Gradle properties**
+(`findProperty("…")`), then falls back to **environment variables**
+(`System.getenv("…")`).
+
+When all four values are present a `signingConfigs.release` block is
+registered and wired to the `release` build type.
+When any value is missing the release artifact is produced **unsigned** —
+safe for local development and debug builds.
+
+## Local Setup (one-time)
+
+1. **Generate a keystore** (skip if you already have one):
+   ```bash
+   keytool -genkeypair -v \
+     -keystore release.jks \
+     -alias upload \
+     -keyalg RSA -keysize 2048 \
+     -validity 10000
+   ```
+   Store the resulting `release.jks` in a safe location **outside** the
+   repository (e.g. `~/keystores/tarot-counter/release.jks`).
+   The `.jks` / `.keystore` extensions are in `.gitignore` as a safety net,
+   but the safest practice is to never place the file inside the repo at all.
+
+2. **Add credentials to your user-level Gradle properties** so they apply
+   to every build on your machine without touching the committed
+   `gradle.properties`:
+
+   ```
+   # ~/.gradle/gradle.properties
+   RELEASE_KEYSTORE_FILE=/home/<you>/keystores/tarot-counter/release.jks
+   RELEASE_KEY_ALIAS=upload
+   RELEASE_KEYSTORE_PASSWORD=your-keystore-password
+   RELEASE_KEY_PASSWORD=your-key-password
+   ```
+
+3. **Build a signed release bundle**:
+   ```bash
+   ./gradlew bundleRelease
+   # Output: app/build/outputs/bundle/release/app-release.aab
+   ```
+
+## CI / CD Setup
+
+Set the four values as **secret environment variables** in your pipeline
+(GitHub Actions secrets, GitLab CI variables, etc.):
+
+```
+RELEASE_KEYSTORE_FILE   # path where the keystore is written on the runner
+RELEASE_KEYSTORE_PASSWORD
+RELEASE_KEY_ALIAS
+RELEASE_KEY_PASSWORD
+```
+
+A typical GitHub Actions step also needs to decode the keystore from a
+base64 secret and write it to disk before invoking Gradle:
+
+```yaml
+- name: Decode keystore
+  run: |
+    echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 --decode \
+      > $RUNNER_TEMP/release.jks
+  env:
+    RELEASE_KEYSTORE_FILE: ${{ runner.temp }}/release.jks
+
+- name: Build release bundle
+  run: ./gradlew bundleRelease
+  env:
+    RELEASE_KEYSTORE_FILE: ${{ runner.temp }}/release.jks
+    RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+    RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+    RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+```
+
+## Security Notes
+
+- **Never commit** passwords, keystore files, or any file containing real
+  credentials to source control.
+- The project-level `gradle.properties` (committed) contains only
+  **commented-out placeholder lines** — no real values.
+- Real values live in `~/.gradle/gradle.properties` locally (not committed)
+  or in pipeline secrets on CI.
+- `.gitignore` blocks `*.jks` and `*.keystore` as an extra safety net.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,24 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+# ── Release signing ────────────────────────────────────────────────────────────
+# DO NOT put real passwords here — this file is committed to source control.
+# Supply values in ONE of these two ways (build.gradle.kts tries both in order):
+#
+#   Option A — local override (never committed):
+#     Add the four lines below (uncommented, with real values) to
+#     ~/.gradle/gradle.properties   ← applies to every project on this machine
+#
+#   Option B — CI environment variables:
+#     Set RELEASE_KEYSTORE_FILE, RELEASE_KEYSTORE_PASSWORD,
+#     RELEASE_KEY_ALIAS, RELEASE_KEY_PASSWORD in your pipeline secrets.
+#
+# Path to the keystore file, relative to the app/ module directory or absolute.
+# RELEASE_KEYSTORE_FILE=../keystore/release.jks
+# Alias of the key inside the keystore to use for signing.
+# RELEASE_KEY_ALIAS=upload
+# Password protecting the keystore file.
+# RELEASE_KEYSTORE_PASSWORD=
+# Password protecting the individual key (often the same as the keystore password).
+# RELEASE_KEY_PASSWORD=


### PR DESCRIPTION
## Summary

- Adds a `signingConfigs { release { … } }` block to `app/build.gradle.kts` that reads credentials from Gradle properties (`findProperty`) with env-var fallback (`System.getenv`) — secrets are never hardcoded or committed
- The signing config is registered **only when all four values are present**; if any is missing the release artifact is produced unsigned (safe for local dev and debug builds)
- Adds commented placeholder keys to `gradle.properties` as a template — real values go in `~/.gradle/gradle.properties` (local) or pipeline secrets (CI)
- Adds `*.jks` / `*.keystore` to `.gitignore` as a safety net against accidentally committing a keystore file
- Adds `docs/release-signing.md` with step-by-step local and GitHub Actions CI/CD setup instructions
- Updates README with `bundleRelease` command and signing credential table

## Credential property names

| Property / env var | Description |
|---|---|
| `RELEASE_KEYSTORE_FILE` | Path to the `.jks` keystore (relative to `app/` or absolute) |
| `RELEASE_KEYSTORE_PASSWORD` | Keystore password |
| `RELEASE_KEY_ALIAS` | Key alias |
| `RELEASE_KEY_PASSWORD` | Key password |

## Test plan

- [x] `./gradlew testDebugUnitTest` — all unit tests pass
- [x] `./gradlew lint` — no new warnings
- [ ] Local: add credentials to `~/.gradle/gradle.properties` → `./gradlew bundleRelease` produces a signed `.aab`
- [ ] Local: omit credentials → `./gradlew assembleRelease` completes without error (unsigned output)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)