### PR TITLE
feat(#42): enable R8 minification and resource shrinking for release builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ are supplied via `~/.gradle/gradle.properties` (local) or environment variables 
 
 See [`docs/release-signing.md`](docs/release-signing.md) for full setup instructions.
 
+### R8 Minification
+
+Release builds automatically minify and shrink resources (`isMinifyEnabled = true`,
+`isShrinkResources = true`). Project-specific ProGuard rules live in
+`app/proguard-rules.pro` — see [`docs/release-signing.md`](docs/release-signing.md)
+for details.
+
 ## Testing
 
 ```bash

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,9 +71,15 @@ android {
             // Wire the signing config when credentials were provided; otherwise
             // the artifact is left unsigned (you must sign it manually before upload).
             signingConfig = signingConfigs.findByName("release")
-            isMinifyEnabled = false
+            // R8 minification: shrinks bytecode by removing unused code and renaming symbols.
+            isMinifyEnabled = true
+            // Resource shrinking: strips unused drawables, layouts, strings, etc. from the APK.
+            // Must be used together with isMinifyEnabled = true.
+            isShrinkResources = true
             proguardFiles(
+                // Google's optimised baseline rules bundled with AGP (handles most Android cases).
                 getDefaultProguardFile("proguard-android-optimize.txt"),
+                // Project-specific rules (see app/proguard-rules.pro).
                 "proguard-rules.pro"
             )
         }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,21 +1,28 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# ── Stack traces ─────────────────────────────────────────────────────────────
+# Preserve file names and line numbers so crash reports remain readable.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# ── kotlinx.serialization ────────────────────────────────────────────────────
+# The library ships its own consumer rules (via its AAR), but the rules below
+# are the recommended explicit additions for app code.
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# Keep all annotations (required for @Serializable, @SerialName, etc. to work).
+-keepattributes *Annotation*, InnerClasses
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# Keep the generated $$serializer classes that R8 would otherwise strip.
+# These classes are created at compile time for every @Serializable class.
+-keep,includedescriptorclasses class fr.mandarine.tarotcounter.**$$serializer { *; }
+
+# Keep companion objects that expose a serializer() method (used by Json.encode/decode).
+-keepclassmembers class fr.mandarine.tarotcounter.** {
+    *** Companion;
+}
+-keepclasseswithmembers class fr.mandarine.tarotcounter.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# ── Jetpack Compose ───────────────────────────────────────────────────────────
+# Compose libraries bundle their own consumer ProGuard rules inside their AARs,
+# so no extra rules are required here.  The proguard-android-optimize.txt
+# baseline (referenced in build.gradle.kts) covers the Android framework side.

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -88,6 +88,27 @@ base64 secret and write it to disk before invoking Gradle:
     RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
 ```
 
+## R8 Minification & Resource Shrinking
+
+Release builds have `isMinifyEnabled = true` and `isShrinkResources = true` in
+`app/build.gradle.kts`. This means:
+
+- **R8** (Google's replacement for ProGuard) rewrites and shrinks bytecode,
+  removing unused classes, methods and fields, and renaming remaining symbols.
+- **Resource shrinking** strips unused drawables, layouts, strings, etc. from
+  the APK/AAB, reducing binary size further.
+
+Rules that tell R8 what *not* to remove are in `app/proguard-rules.pro`:
+
+| Rule category | Why it is needed |
+|---|---|
+| `SourceFile,LineNumberTable` attributes | Keeps crash stack traces readable |
+| `fr.mandarine.tarotcounter.**$$serializer` | Generated serializer classes for every `@Serializable` data class / enum; R8 would otherwise strip them |
+| Companion objects with `serializer()` | `Json.encodeToString` / `decodeFromString` look these up reflectively at runtime |
+
+The Compose libraries and `kotlinx.serialization` AAR each ship their own
+consumer ProGuard rules, so no extra Compose-specific rules are needed here.
+
 ## Security Notes
 
 - **Never commit** passwords, keystore files, or any file containing real


### PR DESCRIPTION
## Summary

- Enables `isMinifyEnabled = true` and `isShrinkResources = true` in the `release` build type in `app/build.gradle.kts`
- Replaces the empty `proguard-rules.pro` with explicit rules for:
  - `kotlinx.serialization` (keep `$$serializer` classes and companion objects with `serializer()`)
  - Stack trace readability (`SourceFile`, `LineNumberTable` attributes)
- Documents the R8 setup in `docs/release-signing.md` and `README.md`

## Test plan

- [x] `./gradlew assembleRelease` — BUILD SUCCESSFUL with `minifyReleaseWithR8` task executed
- [x] `./gradlew testDebugUnitTest lint` — BUILD SUCCESSFUL, no new warnings

Closes #42