### PR TITLE
docs(#45): add App Bundle build verification and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ are supplied via `~/.gradle/gradle.properties` (local) or environment variables 
 | `RELEASE_KEY_ALIAS` | Key alias |
 | `RELEASE_KEY_PASSWORD` | Key password |
 
-See [`docs/release-signing.md`](docs/release-signing.md) for full setup instructions.
+See [`docs/release-signing.md`](docs/release-signing.md) for full setup instructions and [`docs/app-bundle.md`](docs/app-bundle.md) for App Bundle / Play Store submission details.
 
 ### R8 Minification
 

--- a/docs/app-bundle.md
+++ b/docs/app-bundle.md
@@ -1,0 +1,61 @@
+# App Bundle (AAB) for Google Play
+
+Google Play requires **Android App Bundles** (`.aab`) instead of APKs for all
+new app submissions. This document explains what an App Bundle is, how to build
+one, and how to verify the output.
+
+## What is an App Bundle?
+
+An APK (Android Package) is a self-contained installable file that must include
+resources for every device configuration (screen density, CPU architecture, etc.).
+
+An AAB (Android App Bundle) is a publishing format. You upload it to Google Play,
+and Play's servers generate optimised, device-specific APKs from it on the fly.
+The result is a smaller download for the end user.
+
+AGP 9.1+ (used in this project) supports `bundleRelease` out of the box — no
+extra plugins or configuration are required.
+
+## Build the App Bundle
+
+```bash
+# Requires signing credentials to be configured — see docs/release-signing.md
+./gradlew bundleRelease
+```
+
+Output path:
+```
+app/build/outputs/bundle/release/app-release.aab
+```
+
+## Verify the Output
+
+After the build completes, confirm the file exists:
+
+```bash
+ls -lh app/build/outputs/bundle/release/app-release.aab
+```
+
+You can also inspect the bundle with Google's
+[`bundletool`](https://developer.android.com/tools/bundletool):
+
+```bash
+# Download bundletool from https://github.com/google/bundletool/releases
+java -jar bundletool.jar validate --bundle=app/build/outputs/bundle/release/app-release.aab
+```
+
+## Signing
+
+The `.aab` produced by `bundleRelease` is signed with the release key configured
+in `app/build.gradle.kts`. See [`docs/release-signing.md`](release-signing.md)
+for full keystore setup and CI/CD instructions.
+
+If signing credentials are **not** configured, the bundle is produced unsigned and
+cannot be uploaded to the Play Store.
+
+## Uploading to Google Play
+
+1. Go to the [Google Play Console](https://play.google.com/console).
+2. Navigate to your app → **Production** (or an internal/alpha/beta track).
+3. Create a new release and upload `app-release.aab`.
+4. Complete the release checklist and submit for review.


### PR DESCRIPTION
## Summary

- Verifies `./gradlew bundleRelease` completes successfully and produces `app/build/outputs/bundle/release/app-release.aab` ✅
- Adds `docs/app-bundle.md`: explains AAB vs APK, build command, output path, `bundletool` validation, signing, and Play Store upload steps
- Updates README to link to the new doc alongside the existing release-signing reference

## Test plan

- [x] `./gradlew bundleRelease` runs without errors (BUILD SUCCESSFUL)
- [x] `app/build/outputs/bundle/release/app-release.aab` present
- [x] `./gradlew lint` passes with no new warnings

Closes #45