### PR TITLE
fix(#61): prevent duplicate history entry when ending game multiple times

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -98,6 +98,23 @@ fun GameScreen(
     val locale = LocalAppLocale.current
     val strings = appStrings(locale)
 
+    // Stable UUID for this game session, used as SavedGame.id when the game is ended.
+    //
+    // Generating the ID here (once, via `remember`) rather than inside `endGame()` ensures
+    // that calling `endGame()` multiple times — e.g. pressing "End Game" again after
+    // navigating back from the Final Score screen — always produces the same ID.
+    // GameStorage then treats a repeated save as an upsert (update) rather than an insert,
+    // preventing duplicate entries in the history list.
+    //
+    // When resuming a saved game the stored `gameId` is reused so that the resumed game
+    // updates the same history entry it would have created if ended the first time.
+    // Old InProgressGame entries that predate this field will have gameId == ""; in that
+    // case we generate a fresh UUID to ensure the ID is always a valid, non-empty string.
+    val gameId = remember {
+        inProgressGame?.gameId?.ifBlank { UUID.randomUUID().toString() }
+            ?: UUID.randomUUID().toString()
+    }
+
     // Current round number — restored from the saved state when resuming, otherwise 1.
     var currentRound by remember { mutableIntStateOf(inProgressGame?.currentRound ?: 1) }
 
@@ -136,7 +153,10 @@ fun GameScreen(
     val displayNames = playerNames.indices.map { displayName(it) }
 
     // Builds an InProgressGame snapshot from the current game state.
+    // `gameId` is included so that if the game is resumed later, the same ID is
+    // carried through to the final SavedGame (preventing duplicate history entries).
     fun progressSnapshot() = InProgressGame(
+        gameId        = gameId,
         playerNames   = displayNames,
         currentRound  = currentRound,
         startingIndex = startingIndex,
@@ -171,10 +191,16 @@ fun GameScreen(
     }
 
     // Saves the completed game and shows the Final Score screen.
+    //
+    // Uses the stable `gameId` (generated once in `remember` above) rather than a
+    // freshly generated UUID so that repeated calls — e.g. the user presses "End Game"
+    // again after navigating back — always produce the same SavedGame.id.
+    // GameStorage's upsert logic will then replace the existing history entry instead
+    // of inserting a duplicate.
     fun endGame() {
         if (roundHistory.isNotEmpty()) {
             val savedGame = SavedGame(
-                id          = UUID.randomUUID().toString(),
+                id          = gameId,
                 datestamp   = System.currentTimeMillis(),
                 playerNames = displayNames,
                 rounds      = roundHistory.toList(),

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameStorage.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameStorage.kt
@@ -156,7 +156,15 @@ class GameStorage(private val context: Context) : GameStorageInterface {
         }
     }
 
-    // Prepends `game` to the saved games list and persists it to disk.
+    // Upserts `game` into the saved games list and persists the result to disk.
+    //
+    // "Upsert" means:
+    //   - If a game with the same `id` already exists (e.g. the user ended the same
+    //     game twice by pressing "End Game" after navigating back from the Final Score
+    //     screen), the existing entry is replaced in-place. No duplicate is created.
+    //   - If no game with that `id` exists, the new game is prepended (newest-first).
+    //
+    // In both cases the list is trimmed to MAX_SAVED_GAMES afterwards.
     //
     // `suspend` means this function must be called from a coroutine (it does I/O).
     // `DataStore.edit` is a suspend function that atomically reads, modifies, and
@@ -166,8 +174,19 @@ class GameStorage(private val context: Context) : GameStorageInterface {
             val raw = prefs[GAMES_KEY] ?: "[]"
             val existing = runCatching { json.decodeFromString<List<SavedGame>>(raw) }
                 .getOrDefault(emptyList())
-            // Prepend the new game (newest-first) and trim to the allowed limit in one step.
-            val updated = (listOf(game) + existing).take(MAX_SAVED_GAMES)
+
+            // Check whether a game with this ID is already stored.
+            val alreadyExists = existing.any { it.id == game.id }
+
+            val updated = if (alreadyExists) {
+                // Replace the existing entry and keep its current position in the list.
+                // `map` returns a new list with the matching element swapped out.
+                existing.map { if (it.id == game.id) game else it }
+            } else {
+                // New game: prepend so the list stays newest-first.
+                listOf(game) + existing
+            }.take(MAX_SAVED_GAMES)   // always enforce the storage cap
+
             prefs[GAMES_KEY] = json.encodeToString(updated)
         }
     }

--- a/app/src/main/java/fr/mandarine/tarotcounter/SavedGame.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/SavedGame.kt
@@ -26,6 +26,14 @@ data class SavedGame(
 // It is written to DataStore after every round so that if the app is closed,
 // the game can be resumed exactly where it left off.
 //
+//   gameId        : a stable UUID generated when the game starts. It is carried all
+//                   the way through to SavedGame.id when the game is ended. This
+//                   guarantees that ending the same game multiple times (e.g. after
+//                   navigating back from the Final Score screen) always produces the
+//                   same ID, so GameStorage can upsert instead of duplicating.
+//                   Default "" means the field is optional in stored JSON — old
+//                   DataStore entries without this field deserialise safely, and
+//                   GameScreen generates a fresh UUID whenever it encounters a blank.
 //   playerNames   : display names used during the game (already resolved from raw input).
 //   currentRound  : the round number that would be played next (always ≥ 2 after the
 //                   first round, because saving happens after incrementing).
@@ -34,6 +42,7 @@ data class SavedGame(
 //   rounds        : all rounds completed so far, in chronological order.
 @Serializable
 data class InProgressGame(
+    val gameId: String = "",
     val playerNames: List<String>,
     val currentRound: Int,
     val startingIndex: Int,

--- a/app/src/test/java/fr/mandarine/tarotcounter/FakeGameStorage.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/FakeGameStorage.kt
@@ -73,8 +73,15 @@ class FakeGameStorage : GameStorageInterface {
     override suspend fun addGame(game: SavedGame) {
         addGameCallCount++
         lastAddedGame = game
-        // Mirror the production rule: newest game at the front of the list.
-        _games.value = listOf(game) + _games.value
+        // Mirror the production upsert rule:
+        //   - If a game with the same id already exists, replace it in-place.
+        //   - Otherwise prepend (newest-first).
+        val existing = _games.value
+        _games.value = if (existing.any { it.id == game.id }) {
+            existing.map { if (it.id == game.id) game else it }
+        } else {
+            listOf(game) + existing
+        }
     }
 
     override suspend fun saveInProgressGame(game: InProgressGame) {

--- a/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
@@ -106,6 +106,29 @@ class GameViewModelTest {
         assertEquals("clearInProgressGame should have been called", 1, storage.clearInProgressCallCount)
     }
 
+    @Test
+    fun `saveGame twice with the same id does not create a duplicate in pastGames`() = runTest {
+        // Regression test for: game saved twice when user ends game, navigates back,
+        // and ends it again. The second save must replace the first, not append.
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+        val game = savedGame("same-id")
+
+        val collected = mutableListOf<List<SavedGame>>()
+        val job = launch(testDispatcher) { vm.pastGames.collect { collected.add(it) } }
+
+        vm.saveGame(game)
+        // Save the same game again (same id, possibly different datestamp).
+        vm.saveGame(game.copy(datestamp = 99L))
+
+        // The list must contain exactly one entry, not two.
+        assertEquals("History should have exactly one entry after saving the same game twice",
+            1, collected.last().size)
+        // The stored entry should be the second (most-recent) version.
+        assertEquals(99L, collected.last().first().datestamp)
+        job.cancel()
+    }
+
     // ── saveInProgressGame ────────────────────────────────────────────────────
 
     @Test

--- a/docs/game-persistence.md
+++ b/docs/game-persistence.md
@@ -20,7 +20,7 @@ A completed `SavedGame` entry is written the moment the user presses **End Game*
 
 - Closing the app while the Final Score screen is open still records the game in Past Games.
 - Pressing **New Game** afterwards just navigates to the setup screen; no second save occurs.
-- Pressing **Back to game** after End Game keeps the saved entry in Past Games and lets the player continue; if they press **End Game** again later, a new entry is created with the updated round history.
+- Pressing **Back to game** after End Game keeps the saved entry in Past Games and lets the player continue; if they press **End Game** again later, the existing entry is **updated** (not duplicated) because the game ID is stable for the whole session.
 - If no rounds were played when End Game is pressed, nothing is saved (nothing to record).
 
 ## What Is Stored
@@ -29,6 +29,7 @@ A completed `SavedGame` entry is written the moment the user presses **End Game*
 
 | Field | Type | Description |
 |---|---|---|
+| `gameId` | `String` | UUID generated when the game starts. Carried through to `SavedGame.id` so that ending the same game twice produces the same ID (upsert, not duplicate). Defaults to `""` for backwards-compatible deserialization of old saved data. |
 | `playerNames` | `List<String>` | Display names used during the game |
 | `currentRound` | `Int` | The round number to play next |
 | `startingIndex` | `Int` | Index of the first taker — needed to restore the rotation formula |
@@ -38,7 +39,7 @@ A completed `SavedGame` entry is written the moment the user presses **End Game*
 
 | Field | Type | Description |
 |---|---|---|
-| `id` | `String` | UUID generated at save time — uniquely identifies the game |
+| `id` | `String` | UUID sourced from `InProgressGame.gameId` — stable for the entire game session, preventing duplicate history entries |
 | `datestamp` | `Long` | Unix timestamp in milliseconds (`System.currentTimeMillis()`) |
 | `playerNames` | `List<String>` | Display names at the time the game was played |
 | `rounds` | `List<RoundResult>` | Full round history in chronological order |


### PR DESCRIPTION
## Summary

- **Root cause**: `endGame()` called `UUID.randomUUID()` on every invocation, so pressing \"End Game\" twice (after navigating back from the Final Score screen) created two `SavedGame` entries with different IDs.
- **Fix**: Added a stable `gameId` field to `InProgressGame` (generated once via `remember` in `GameScreen`, persisted through every round snapshot). `endGame()` now reuses that ID instead of generating a new one.
- **Storage upsert**: `GameStorage.addGame()` now replaces an existing entry with the same `id` instead of always prepending — the second save updates the record rather than duplicating it. `FakeGameStorage` mirrors this.
- **Backwards-compatible**: `gameId` defaults to `""` in `InProgressGame`, so existing serialized data deserialises safely; `GameScreen` generates a fresh UUID whenever it encounters a blank.

## Test plan

- [x] New unit test: saving the same game ID twice results in exactly one history entry with the latest data (`GameViewModelTest`)
- [x] All existing unit tests pass (`./gradlew testDebugUnitTest` — 24 tests)
- [x] Lint clean (`./gradlew lint`)

Closes #61