### PR TITLE
docs(#44): write privacy policy for Play Store listing

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -8,7 +8,7 @@ Tarot Counter is a simple scoring application for the tarot card game. We are co
 
 ## 2. What Data We Collect
 
-**We collect no personal data.** Period.
+**We collect no personal data.**
 
 Specifically, Tarot Counter:
 - Does not require an account or login
@@ -41,7 +41,7 @@ We may update this privacy policy from time to time. Any changes will be effecti
 
 ## 7. Contact
 
-If you have questions about this privacy policy, you may contact us through the GitHub repository:
+If you have questions about this privacy policy, you may contact us via an email to mandarinetech.dev@gmail.com or through the GitHub repository:
 https://github.com/emmanuel-h/tarot-counter
 
 ---


### PR DESCRIPTION
## Summary
- Write a comprehensive privacy policy document for Tarot Counter
- Address Google Play's requirement for a privacy policy URL
- Clarify that the app collects no personal data
- Explain local-only storage and data handling

## Implementation Details
Created `docs/privacy-policy.md` with:
- Clear statement: no personal data collection
- Explanation of local storage
- Third-party service clarification (none used)
- Children's privacy compliance
- Contact information

This completes step 1 of #44. Steps 2-3 (hosting and Play Console entry) will follow.