### PR TITLE
feat(65): add /release-store skill for automated Play Store publishing

### DIFF
--- a/.claude/skills/release-store/SKILL.md
+++ b/.claude/skills/release-store/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: release-store
+description: Automate the full TarotCounter release workflow — bump semver, build signed AAB, create GitHub release, upload artifact. Use when the user wants to publish a new version to the Play Store.
+argument-hint: "[major|minor|hotfix]  (default: minor)"
+allowed-tools: Bash Read Edit Glob Grep Write
+---
+
+Automate the full TarotCounter release workflow.
+
+## Input
+
+`$ARGUMENTS` contains the release type: `major`, `minor`, or `hotfix`.
+Default to `minor` if the argument is absent or unrecognised.
+
+---
+
+## Step 1 — Parse the release type
+
+```
+RELEASE_TYPE="${ARGUMENTS:-minor}"
+if [[ "$RELEASE_TYPE" != "major" && "$RELEASE_TYPE" != "minor" && "$RELEASE_TYPE" != "hotfix" ]]; then
+  RELEASE_TYPE="minor"
+fi
+echo "Release type: $RELEASE_TYPE"
+```
+
+---
+
+## Step 2 — Read the current version from `app/build.gradle.kts`
+
+Use `grep` with a Perl-compatible regex to extract the two version fields:
+
+```bash
+# Integer build number — incremented on every release.
+CURRENT_CODE=$(grep -oP 'versionCode\s*=\s*\K[0-9]+' app/build.gradle.kts)
+
+# Human-readable semver string, e.g. "1.2" or "1.2.3".
+CURRENT_NAME=$(grep -oP 'versionName\s*=\s*"\K[^"]+' app/build.gradle.kts)
+
+echo "Current: versionCode=$CURRENT_CODE  versionName=$CURRENT_NAME"
+```
+
+---
+
+## Step 3 — Calculate the next version
+
+Split `CURRENT_NAME` on `.` into MAJOR, MINOR, and PATCH components.
+PATCH defaults to 0 if the current name has only two parts.
+
+```bash
+IFS='.' read -r VER_MAJOR VER_MINOR VER_PATCH <<< "$CURRENT_NAME"
+VER_PATCH="${VER_PATCH:-0}"
+
+case "$RELEASE_TYPE" in
+  major)
+    # X.0.0  →  (X+1).0.0
+    VER_MAJOR=$((VER_MAJOR + 1))
+    VER_MINOR=0
+    VER_PATCH=0
+    ;;
+  minor)
+    # X.Y    →  X.(Y+1)
+    VER_MINOR=$((VER_MINOR + 1))
+    VER_PATCH=0
+    ;;
+  hotfix)
+    # X.Y.Z  →  X.Y.(Z+1)  [Z starts at 1 if the current name has no patch]
+    VER_PATCH=$((VER_PATCH + 1))
+    ;;
+esac
+
+NEW_CODE=$((CURRENT_CODE + 1))
+
+# For major/minor releases, omit the ".0" patch segment to keep names tidy.
+# For hotfix, always include the patch segment.
+if [[ "$RELEASE_TYPE" == "hotfix" ]]; then
+  NEW_NAME="${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}"
+else
+  NEW_NAME="${VER_MAJOR}.${VER_MINOR}"
+fi
+
+echo "Next:    versionCode=$NEW_CODE  versionName=$NEW_NAME"
+```
+
+---
+
+## Step 4 — Confirm with the user
+
+Show the user the planned version bump before touching any file:
+
+```
+Current version : $CURRENT_NAME  (code $CURRENT_CODE)
+Next version    : $NEW_NAME      (code $NEW_CODE)
+Release type    : $RELEASE_TYPE
+```
+
+Ask: **"Proceed with this version bump and release? (yes/no)"**
+
+If the user says no, stop and let them specify the correct release type.
+
+---
+
+## Step 5 — Patch `app/build.gradle.kts`
+
+Use `sed` in-place to replace both version fields:
+
+```bash
+sed -i "s/versionCode\s*=\s*${CURRENT_CODE}/versionCode = ${NEW_CODE}/" app/build.gradle.kts
+sed -i "s/versionName\s*=\s*\"${CURRENT_NAME}\"/versionName = \"${NEW_NAME}\"/" app/build.gradle.kts
+```
+
+Verify the replacement:
+
+```bash
+grep -E 'versionCode|versionName' app/build.gradle.kts
+```
+
+---
+
+## Step 6 — Build the signed App Bundle
+
+```bash
+./gradlew bundleRelease
+```
+
+The output artifact will be at:
+```
+app/build/outputs/bundle/release/app-release.aab
+```
+
+If the build fails, show the error output to the user and stop.
+
+---
+
+## Step 7 — Commit the version bump
+
+Stage only the build file (no secrets, no `.aab` binary):
+
+```bash
+git add app/build.gradle.kts
+git commit -m "chore: bump version to ${NEW_NAME} (code ${NEW_CODE})"
+```
+
+---
+
+## Step 8 — Create the GitHub release and upload the artifact
+
+```bash
+TAG="v${NEW_NAME}"
+
+# Create an annotated release on GitHub.
+# --generate-notes asks GitHub to auto-generate a changelog from merged PRs/commits.
+gh release create "$TAG" \
+  --title "TarotCounter $NEW_NAME" \
+  --generate-notes
+
+# Attach the signed App Bundle to the release.
+gh release upload "$TAG" \
+  "app/build/outputs/bundle/release/app-release.aab" \
+  --clobber
+```
+
+---
+
+## Step 9 — Display the artifact download URL
+
+```bash
+gh release view "$TAG" --json assets \
+  --jq '.assets[] | select(.name | endswith(".aab")) | .browserDownloadUrl'
+```
+
+Display the URL clearly to the user.
+
+Also remind the user:
+- Upload the `.aab` to **Google Play Console → Production (or Internal testing) → Create new release**.
+- The same signing keystore must be used for every future release.
+- Push the version-bump commit: `git push`.
+
+---
+
+## Summary output
+
+End with a short summary block:
+
+```
+✓ Version bumped  : $CURRENT_NAME (code $CURRENT_CODE) → $NEW_NAME (code $NEW_CODE)
+✓ AAB built       : app/build/outputs/bundle/release/app-release.aab
+✓ GitHub release  : https://github.com/emmanuel-h/tarot-counter/releases/tag/$TAG
+✓ Download URL    : <url from step 9>
+```

--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ are supplied via `~/.gradle/gradle.properties` (local) or environment variables 
 
 See [`docs/release-signing.md`](docs/release-signing.md) for full setup instructions and [`docs/app-bundle.md`](docs/app-bundle.md) for App Bundle / Play Store submission details.
 
+### Publishing a Release
+
+Use the `/release-store` skill to automate the full release workflow in one step:
+
+```
+/release-store minor    # bump minor version (default)
+/release-store major    # bump major version
+/release-store hotfix   # bump patch version
+```
+
+The skill bumps `versionCode` / `versionName` in `app/build.gradle.kts`, builds the signed `.aab`, creates a GitHub release with auto-generated notes, and uploads the artifact. See [`docs/release-workflow.md`](docs/release-workflow.md) for details.
+
 ### R8 Minification
 
 Release builds automatically minify and shrink resources (`isMinifyEnabled = true`,
@@ -179,7 +191,8 @@ TarotCounter/
 │   ├── score-color.md        # Score colour-coding convention and scoreColor() helper
 │   ├── theme.md              # Colour palette rationale and dynamic-colour policy
 │   ├── app-name.md           # App name branding and locale-specific launcher labels
-│   └── release-signing.md    # Release signing setup for local dev and CI
+│   ├── release-signing.md    # Release signing setup for local dev and CI
+│   └── release-workflow.md   # /release-store skill: full publish workflow
 ├── gradle/
 │   └── libs.versions.toml  # Dependency version catalog
 ├── CLAUDE.md               # AI assistant instructions
@@ -201,3 +214,4 @@ More detailed documentation lives in [`docs/`](docs/):
 - [`docs/back-navigation.md`](docs/back-navigation.md) — system back button behaviour per screen, BackHandler implementation, confirmation dialog
 - [`docs/app-name.md`](docs/app-name.md) — app name branding, locale-specific launcher labels, and how the system name and in-app title relate
 - [`docs/release-signing.md`](docs/release-signing.md) — how to configure release signing for local builds and CI/CD pipelines
+- [`docs/release-workflow.md`](docs/release-workflow.md) — automated release workflow via `/release-store` skill (version bump, AAB build, GitHub release)

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -1,0 +1,68 @@
+# Release Workflow
+
+This document describes how to publish a new version of TarotCounter to the Play Store using the `/release-store` skill.
+
+## Quick start
+
+```
+/release-store minor
+```
+
+That single command will:
+1. Bump the version (see [Versioning](#versioning) below)
+2. Build a signed App Bundle (`.aab`)
+3. Create a GitHub release with auto-generated release notes
+4. Upload the `.aab` as a release asset
+5. Print the download URL
+
+## Prerequisites
+
+- Signing credentials must be configured (see [`docs/release-signing.md`](release-signing.md))
+- `gh` CLI must be authenticated (`gh auth status`)
+- You must be on the `main` branch with a clean working tree
+
+## Versioning
+
+TarotCounter follows [Semantic Versioning](https://semver.org/) with two or three components:
+
+| Release type | Command | Version change | Example |
+|---|---|---|---|
+| `minor` (default) | `/release-store` or `/release-store minor` | X.**Y** → X.**(Y+1)** | `1.2` → `1.3` |
+| `major` | `/release-store major` | **X**.Y → **(X+1)**.0 | `1.2` → `2.0` |
+| `hotfix` | `/release-store hotfix` | X.Y.**Z** → X.Y.**(Z+1)** | `1.2` → `1.2.1` |
+
+`versionCode` (the integer Play Store uses internally) is always incremented by 1 regardless of release type.
+
+Both values are stored in `app/build.gradle.kts`:
+
+```kotlin
+defaultConfig {
+    versionCode = 1       // integer, must increase on every upload
+    versionName = "1.0"  // human-readable string shown in the Play Store
+}
+```
+
+## What the skill does step by step
+
+1. **Parse release type** — reads `$ARGUMENTS`, defaults to `minor`.
+2. **Read current version** — extracts `versionCode` and `versionName` from `app/build.gradle.kts`.
+3. **Confirm** — shows you the planned bump and waits for approval before changing anything.
+4. **Patch `build.gradle.kts`** — updates both fields in place with `sed`.
+5. **Build** — runs `./gradlew bundleRelease`; output is `app/build/outputs/bundle/release/app-release.aab`.
+6. **Commit** — stages only `app/build.gradle.kts` and commits the version bump.
+7. **GitHub release** — runs `gh release create vX.Y[.Z] --generate-notes` and uploads the `.aab`.
+8. **Display URL** — retrieves and prints the asset download URL via `gh release view`.
+
+## After the skill finishes
+
+1. Push the version-bump commit: `git push`
+2. Open [Google Play Console](https://play.google.com/console)
+3. Go to **Production** (or an internal / alpha track) → **Create new release**
+4. Upload the `.aab` file
+5. Review and roll out
+
+## Important reminders
+
+- The signing keystore must be the same for every release. Losing it means you can never update the app on the Play Store.
+- Never commit the keystore or `local.properties` / `gradle.properties` credentials to git.
+- `versionCode` must strictly increase on every upload to the Play Store — never reuse a code.


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/release-store/SKILL.md` — a new Claude Code skill that automates the full TarotCounter release workflow
- Adds `docs/release-workflow.md` — usage guide with versioning table, step-by-step explanation, and post-publish checklist
- Updates `README.md` with a "Publishing a Release" section and doc index entries

## What the skill does

When invoked as `/release-store [major|minor|hotfix]` (default: `minor`):

1. Reads current `versionCode` and `versionName` from `app/build.gradle.kts`
2. Calculates the next semver version and confirms with the user before touching any file
3. Patches both version fields in `build.gradle.kts` with `sed`
4. Builds the signed AAB via `./gradlew bundleRelease`
5. Commits the version bump
6. Creates a GitHub release with `gh release create --generate-notes`
7. Uploads the `.aab` with `gh release upload`
8. Displays the artifact download URL

## Test plan

- [ ] Invoke `/release-store minor` on a branch and verify the version bump in `build.gradle.kts`
- [ ] Invoke `/release-store major` and verify MAJOR increments and MINOR resets to 0
- [ ] Invoke `/release-store hotfix` on a `X.Y` version and verify it produces `X.Y.1`
- [ ] Confirm that an invalid argument falls back to `minor`
- [ ] Verify the GitHub release is created with the correct tag and the `.aab` is attached

Closes #65