### PR TITLE
fix(67): remove checkmark icon from camp SegmentedButton

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -459,7 +459,10 @@ fun GameScreen(
                                         defenderMode = false
                                         pointsText   = ""  // clear field when switching camps
                                     },
-                                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2)
+                                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                                    // Remove the default checkmark icon so the label has more space.
+                                    // Selection is still indicated by the filled background color.
+                                    icon  = {}
                                 ) {
                                     // AutoSizeText shrinks the font automatically so long labels
                                     // (e.g. French "Attaquant") always fit inside the button.
@@ -476,7 +479,10 @@ fun GameScreen(
                                         defenderMode = true
                                         pointsText   = ""  // clear field when switching camps
                                     },
-                                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2)
+                                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                                    // Remove the default checkmark icon for consistency with the
+                                    // attacker button — color alone conveys the selected state.
+                                    icon  = {}
                                 ) {
                                     AutoSizeText(
                                         strings.defenderMode,

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -41,12 +41,19 @@ Convergence typically takes 1–3 extra frames, invisible to the user.
 
 **`style` parameter:** pass a `TextStyle` to override the ambient font size, e.g. `MaterialTheme.typography.titleMedium` for a larger call-to-action. All other style properties (color, font family…) are still inherited from the ambient.
 
-**Inside `SegmentedButton`:** always add a horizontal padding modifier so the text stays away from the button's rounded corners:
+**Inside `SegmentedButton`:** always add a horizontal padding modifier so the text stays away from the button's rounded corners, and pass `icon = {}` to suppress the default checkmark — selection state is communicated via the filled background color alone:
 ```kotlin
-AutoSizeText(
-    text     = strings.attackerMode,
-    modifier = Modifier.padding(horizontal = 4.dp)
-)
+SegmentedButton(
+    selected = !defenderMode,
+    onClick  = { … },
+    shape    = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+    icon     = {}   // no checkmark — more space for the label
+) {
+    AutoSizeText(
+        text     = strings.attackerMode,
+        modifier = Modifier.padding(horizontal = 4.dp)
+    )
+}
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Pass `icon = {}` to both `SegmentedButton` segments (attacker & defender) to suppress the default animated checkmark
- Selection state is still communicated by Material 3's filled background color
- Frees up horizontal space for the label, especially for longer translations (e.g. French "Attaquant")

## Test plan
- [ ] Build and run on a device/emulator
- [ ] Verify the attacker/defender toggle has no checkmark when selected
- [ ] Verify the selected segment is visually distinguishable via background color
- [ ] Verify French locale: "Attaquant" and "Défenseur" fit without truncation
- [ ] `./gradlew testDebugUnitTest` passes

Closes #67