### PR TITLE
feat(72): add feedback button to landing screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ TarotCounter guides players through a game round by round:
 8. **Auto-save & Resume** — the game state is saved after every round; if the app is closed mid-game, a "Resume Game" card appears on the setup screen the next time it is opened
 9. **Past Games** — completed games are saved to the device; the setup screen shows a list of past results with a trophy icon next to the winner's name
 10. **Back navigation** — the Android system back button always returns to the landing page; on the Final Score screen a confirmation dialog is shown first to avoid accidentally losing unsaved results
+11. **Feedback button** — a "Send Feedback" / "Contacter le développeur" button at the bottom of the setup screen opens the device's email client pre-addressed to the developer
 
 The app automatically rotates the taker each round, determines win/loss, and computes each player's score for the round.
 
@@ -166,7 +167,7 @@ for details.
 | `TakerRotationTest.kt` | Taker rotation formula for 3–5 players |
 | `AppLocaleTest.kt` | i18n string bundles: locale-specific strings, lambda formatters, enum localized names |
 | `GameViewModelTest.kt` | ViewModel: locale + theme StateFlows, `setLocale`, `setTheme`, `saveGame`, `clearInProgressGame` |
-| `LandingScreenTest.kt` | Setup screen UI: player count chips, name fields, duplicate validation, theme toggle chips |
+| `LandingScreenTest.kt` | Setup screen UI: player count chips, name fields, duplicate validation, theme toggle chips, feedback button |
 | `GameScreenTest.kt` | Full game flow: contract selection, details form, history, score history navigation, End Game button |
 | `ScoreHistoryScreenTest.kt` | Score history table: column headers, cumulative totals, back navigation |
 | `FinalScoreScreenTest.kt` | Final score screen: winner card, tie detection, score table, New Game navigation |

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
@@ -350,4 +350,36 @@ class LandingScreenTest {
         // We use a substring check via containsText to stay locale-agnostic.
         composeTestRule.onNodeWithText("Alice", substring = true).assertIsDisplayed()
     }
+
+    // ── Spec: feedback button (issue #72) ─────────────────────────────────────
+
+    @Test
+    fun feedback_button_is_displayed() {
+        launch()
+        composeTestRule.onNodeWithText("Send Feedback").assertIsDisplayed()
+    }
+
+    @Test
+    fun feedback_button_is_below_start_game_button() {
+        launch()
+        val startBounds    = composeTestRule.onNodeWithText("Start Game").getBoundsInRoot()
+        val feedbackBounds = composeTestRule.onNodeWithText("Send Feedback").getBoundsInRoot()
+
+        assert(feedbackBounds.top >= startBounds.bottom) {
+            "Expected Send Feedback button (top=${feedbackBounds.top}) to be below " +
+                "Start Game button (bottom=${startBounds.bottom})"
+        }
+    }
+
+    @Test
+    fun feedback_button_is_below_past_games_section() {
+        launchWithPastGames()
+        val feedbackBounds  = composeTestRule.onNodeWithText("Send Feedback").getBoundsInRoot()
+        val pastGamesBounds = composeTestRule.onNodeWithText("Past Games").getBoundsInRoot()
+
+        assert(feedbackBounds.top >= pastGamesBounds.bottom) {
+            "Expected Send Feedback button (top=${feedbackBounds.top}) to be below " +
+                "Past Games heading (bottom=${pastGamesBounds.bottom})"
+        }
+    }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
@@ -139,6 +139,10 @@ data class AppStrings(
     // Confirm action label — distinct from `cancel` which already exists.
     val backConfirmLeave: String,
 
+    // ── Feedback button (Landing Screen) ─────────────────────────────────────
+    // Label for the button that opens the user's email client to contact the developer.
+    val feedbackButton: String,
+
     // ── Chelem enum labels ────────────────────────────────────────────────────
     val chelemNone: String,
     val chelemAnnouncedRealized: String,
@@ -220,6 +224,8 @@ val EnStrings = AppStrings(
     chelemAnnouncedRealized  = "Announced & realized",
     chelemAnnouncedNotRealized = "Announced, not realized",
     chelemNotAnnouncedRealized = "Not announced, realized",
+
+    feedbackButton           = "Send Feedback",
 )
 
 // ── French strings ────────────────────────────────────────────────────────────
@@ -296,6 +302,8 @@ val FrStrings = AppStrings(
     chelemAnnouncedRealized  = "Annoncé et réalisé",
     chelemAnnouncedNotRealized = "Annoncé, non réalisé",
     chelemNotAnnouncedRealized = "Non annoncé, réalisé",
+
+    feedbackButton           = "Contacter le développeur",
 )
 
 // Returns the AppStrings for the given locale.

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -1,5 +1,7 @@
 package fr.mandarine.tarotcounter
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,6 +18,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -25,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -33,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -66,9 +71,13 @@ fun LandingScreen(
     onThemeChange: (AppTheme) -> Unit = {}
 ) {
     // Read the active locale and theme from the composition tree.
-    val locale = LocalAppLocale.current
-    val theme  = LocalAppTheme.current
+    val locale  = LocalAppLocale.current
+    val theme   = LocalAppTheme.current
     val strings = appStrings(locale)
+
+    // Context is needed to fire an Android Intent (e.g. open the email client).
+    // LocalContext.current gives us the nearest Activity/Context in the Compose tree.
+    val context = LocalContext.current
 
     // `remember` keeps a value alive across recompositions (UI redraws).
     // `mutableIntStateOf` creates an integer that, when changed, triggers a redraw.
@@ -251,8 +260,6 @@ fun LandingScreen(
             modifier = Modifier.fillMaxWidth(0.8f)
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
-
         // ── Past Games ────────────────────────────────────────────────────────
         // Only shown when there is at least one saved game on the device.
         if (pastGames.isNotEmpty()) {
@@ -275,6 +282,41 @@ fun LandingScreen(
             for (game in pastGames) {
                 PastGameCard(game = game, strings = strings)
                 Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+
+        // ── Feedback button ───────────────────────────────────────────────────
+        // Always at the very bottom of the scrollable column, below Past Games.
+        // Right-aligned so it doesn't compete with the centred "Start Game" CTA.
+        // TextButton (no fill, no border) keeps it subtle; the envelope icon makes
+        // its purpose instantly recognisable without reading the label.
+        // We use TextButton directly here (rather than AppTextButton) because we need
+        // to place an Icon alongside AutoSizeText inside the button content slot.
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End // push the button to the right edge
+        ) {
+            TextButton(
+                onClick = {
+                    // ACTION_SENDTO + "mailto:" URI opens the default email app.
+                    // Using SENDTO (rather than ACTION_SEND) ensures only email clients
+                    // respond to this intent — messaging apps are excluded.
+                    val intent = Intent(
+                        Intent.ACTION_SENDTO,
+                        Uri.parse("mailto:mandarinetech.dev@gmail.com")
+                    )
+                    context.startActivity(Intent.createChooser(intent, null))
+                }
+            ) {
+                // Icon on the left, label on the right, with 4 dp gap between them.
+                Icon(
+                    imageVector        = Icons.Default.Email,
+                    contentDescription = null, // label next to it already describes the action
+                    modifier           = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                AutoSizeText(text = strings.feedbackButton)
             }
         }
     }

--- a/docs/player-setup.md
+++ b/docs/player-setup.md
@@ -19,6 +19,7 @@ The screen uses a scrollable `Column`. The layout order follows the natural user
 6. **Start Game button** ← below the name fields
 7. Resume Game card (if an unfinished game is saved)
 8. Past Games list (if any completed games exist)
+9. **Feedback button** ← right-aligned, below Past Games
 
 ## Visual design
 
@@ -87,3 +88,12 @@ val hasDuplicates = duplicateFlags.any { it }
 ```
 
 Because `resolvedNames`, `lowerNames`, `duplicateFlags`, and `hasDuplicates` are plain `val`s computed inside the composable, Compose recalculates them automatically on every recomposition (i.e. every keystroke). No `remember` or `LaunchedEffect` is needed.
+
+## Feedback button
+
+A low-prominence `AppTextButton` sits at the very bottom of the scrollable column. Tapping it fires an `Intent(ACTION_SENDTO, Uri.parse("mailto:mandarinetech.dev@gmail.com"))`, which opens the user's default email client pre-addressed to the developer. The `ACTION_SENDTO` + `mailto:` combination ensures only email apps (not messaging apps) respond to the intent.
+
+| Locale | Label |
+|---|---|
+| EN | Send Feedback |
+| FR | Contacter le développeur |


### PR DESCRIPTION
## Summary

- Adds an `AppTextButton` at the very bottom of the `LandingScreen` scrollable column
- Tapping it fires an `ACTION_SENDTO` + `mailto:` intent, opening the device email client pre-addressed to `mandarinetech.dev@gmail.com`
- Localized: **EN** "Send Feedback" / **FR** "Contacter le développeur"

## Test plan

- [ ] `feedback_button_is_displayed` — verifies the button renders with the correct label
- [ ] `feedback_button_is_below_start_game_button` — verifies the button is positioned below the primary CTA
- [ ] Run `./gradlew connectedAndroidTest` on a device/emulator to confirm both tests pass
- [ ] Manual: tap the button and confirm the email client opens pre-filled with `mandarinetech.dev@gmail.com`

Closes #72