### PR TITLE
refactor(74): split GameScreen.kt god file

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -1,5 +1,6 @@
 package fr.mandarine.tarotcounter
 
+import android.app.Application
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -10,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
@@ -23,6 +25,10 @@ import org.junit.runner.RunWith
  *
  * These run on a device or emulator via AndroidJUnit4.
  * Run with: ./gradlew connectedAndroidTest
+ *
+ * Each test creates a [GameViewModel] backed by [FakeGameStorage] and calls
+ * [GameViewModel.initGame] before setting the compose content. This avoids relying
+ * on Android DataStore and keeps the tests fast and deterministic.
  *
  * Spec (docs/game-flow.md — Game Screen):
  *   Contract selection — FilterChips for Prise/Garde/Garde Sans/Garde Contre + Skip round.
@@ -39,11 +45,21 @@ class GameScreenTest {
     // Fixed player names used across most tests so assertions are deterministic.
     private val players = listOf("Alice", "Bob", "Charlie")
 
-    /** Launches GameScreen with [players] inside our app theme. */
+    /**
+     * Creates a [GameViewModel] with [FakeGameStorage], initialises it with [playerNames],
+     * and sets the Compose content to [GameScreen].
+     */
     private fun launchGame(playerNames: List<String> = players) {
+        // FakeGameStorage replaces DataStore so no filesystem access is needed.
+        val viewModel = GameViewModel(
+            ApplicationProvider.getApplicationContext<Application>(),
+            FakeGameStorage()
+        )
+        // initGame resolves display names and picks a random starting player.
+        viewModel.initGame(playerNames, inProgressGame = null)
         composeTestRule.setContent {
             TarotCounterTheme {
-                GameScreen(playerNames = playerNames)
+                GameScreen(viewModel = viewModel)
             }
         }
     }
@@ -64,7 +80,6 @@ class GameScreenTest {
         // We cannot predict which player, but one of them must be visible.
         launchGame()
         val anyTakerVisible = players.any { name ->
-            // `substring = true` matches "Alice — choose a contract:" etc.
             composeTestRule.onAllNodesWithText(name, substring = true)
                 .fetchSemanticsNodes().isNotEmpty()
         }
@@ -75,7 +90,6 @@ class GameScreenTest {
 
     @Test
     fun all_four_contract_buttons_are_displayed() {
-        // Spec table: Prise, Garde, Garde Sans, Garde Contre (POUSSE removed).
         launchGame()
         Contract.entries.forEach { contract ->
             composeTestRule.onNodeWithText(contract.displayName).assertIsDisplayed()
@@ -84,7 +98,6 @@ class GameScreenTest {
 
     @Test
     fun pousse_button_does_not_exist() {
-        // POUSSE was removed from the contract list.
         launchGame()
         composeTestRule.onNodeWithText("Pousse").assertDoesNotExist()
     }
@@ -93,14 +106,12 @@ class GameScreenTest {
 
     @Test
     fun skip_round_button_is_displayed_in_bottom_bar() {
-        // "Skip round" must always be visible in the split bottom bar.
         launchGame()
         composeTestRule.onNodeWithText("Skip round").assertIsDisplayed()
     }
 
     @Test
     fun end_game_and_skip_round_buttons_are_both_in_bottom_bar() {
-        // Both primary actions must be visible simultaneously in the bottom bar.
         launchGame()
         composeTestRule.onNodeWithText("End Game").assertIsDisplayed()
         composeTestRule.onNodeWithText("Skip round").assertIsDisplayed()
@@ -108,7 +119,6 @@ class GameScreenTest {
 
     @Test
     fun bottom_bar_buttons_remain_visible_while_contract_form_is_open() {
-        // The bottom bar must not be hidden when the round-details form is expanded.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("End Game").assertIsDisplayed()
@@ -122,7 +132,6 @@ class GameScreenTest {
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
-        // RoundDetailsForm key labels should now be visible.
         composeTestRule.onNodeWithText("Number of bouts (oudlers)").assertIsDisplayed()
         composeTestRule.onNodeWithText("Confirm round").assertIsDisplayed()
     }
@@ -131,7 +140,6 @@ class GameScreenTest {
     fun details_form_shows_selected_contract_in_header() {
         launchGame()
         composeTestRule.onNodeWithText("Garde Sans").performClick()
-        // Header format: "<taker> — Garde Sans"
         composeTestRule
             .onNodeWithText("Garde Sans", substring = true)
             .assertIsDisplayed()
@@ -139,7 +147,6 @@ class GameScreenTest {
 
     @Test
     fun details_form_shows_all_four_chelem_options() {
-        // Spec: four Chelem values with their display names.
         launchGame()
         composeTestRule.onNodeWithText("Prise").performClick()
         Chelem.entries.forEach { chelem ->
@@ -149,17 +156,13 @@ class GameScreenTest {
 
     @Test
     fun details_form_shows_bouts_dropdown_with_0_through_3() {
-        // Issue #9: bouts is now an ExposedDropdownMenuBox instead of FilterChips.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
-        // The dropdown anchor (text field) must be visible with the default value "0".
         composeTestRule.onNodeWithTag("bouts_dropdown").assertIsDisplayed()
 
-        // Open the dropdown to reveal all options.
         composeTestRule.onNodeWithTag("bouts_dropdown").performClick()
 
-        // All four options (0–3) should now be visible in the expanded menu.
         listOf("0", "1", "2", "3").forEach { n ->
             composeTestRule.onAllNodesWithText(n).fetchSemanticsNodes().let { nodes ->
                 assertTrue("Bouts dropdown option '$n' should be visible", nodes.isNotEmpty())
@@ -169,30 +172,23 @@ class GameScreenTest {
 
     @Test
     fun selecting_a_bout_value_from_dropdown_updates_selection() {
-        // Opening the dropdown and picking "2" should update the displayed value.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
-        // Open the dropdown.
         composeTestRule.onNodeWithTag("bouts_dropdown").performClick()
 
-        // Tap the "2" option.
         composeTestRule.onAllNodesWithText("2").fetchSemanticsNodes().let { nodes ->
             assertTrue("Option '2' should be visible in the open dropdown", nodes.isNotEmpty())
         }
-        // The first node with text "2" belongs to the dropdown menu item — click it.
         composeTestRule.onAllNodesWithText("2")[0].performClick()
 
-        // After selection the dropdown anchor should now display "2".
         composeTestRule.onNodeWithTag("bouts_dropdown").assertIsDisplayed()
     }
 
     @Test
     fun details_form_shows_player_names_as_bonus_options() {
-        // Spec: each player-assigned bonus shows "None + one chip per player".
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
-        // Every player should appear at least once in the form as a bonus option.
         players.forEach { name ->
             assertTrue(
                 "$name should appear as a bonus-assignment option",
@@ -231,7 +227,6 @@ class GameScreenTest {
 
     @Test
     fun skipped_round_shows_Skipped_in_history() {
-        // Spec history example: "Round 2: Bob — Skipped"
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()
         composeTestRule
@@ -241,15 +236,12 @@ class GameScreenTest {
 
     @Test
     fun played_round_shows_contract_and_score_in_history() {
-        // Spec history example: "Round 1: Alice — Garde · 2 bouts · 56 pts"
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("Confirm round").performClick()
-        // "Garde" should appear in the history line (substring of full history text).
         composeTestRule
             .onNodeWithText("Garde", substring = true)
             .assertIsDisplayed()
-        // Default bouts=0 and points=0, so history shows "0 bouts · 0 pts".
         composeTestRule
             .onNodeWithText("0 pts", substring = true)
             .assertIsDisplayed()
@@ -257,8 +249,7 @@ class GameScreenTest {
 
     @Test
     fun played_round_shows_Lost_in_history_when_taker_did_not_reach_threshold() {
-        // Default form values: 0 bouts, 0 points.
-        // With 0 bouts the taker needs 56 pts; 0 < 56 → Lost.
+        // Default form values: 0 bouts, 0 points → needs 56 → Lost.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("Confirm round").performClick()
@@ -269,12 +260,10 @@ class GameScreenTest {
 
     @Test
     fun history_is_newest_round_first() {
-        // Complete two rounds; round 2 summary should appear before round 1.
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick() // round 1 skipped
         composeTestRule.onNodeWithText("Skip round").performClick() // round 2 skipped
 
-        // Both entries must be present.
         composeTestRule.onNodeWithText("Round 1", substring = true).assertIsDisplayed()
         composeTestRule.onNodeWithText("Round 2", substring = true).assertIsDisplayed()
     }
@@ -283,13 +272,11 @@ class GameScreenTest {
 
     @Test
     fun scores_section_appears_after_first_played_round() {
-        // After completing a round, a "Scores" heading and player names should be visible.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("Confirm round").performClick()
 
         composeTestRule.onNodeWithText("Scores").assertIsDisplayed()
-        // All player names should appear in the scoreboard.
         players.forEach { name ->
             assertTrue(
                 "$name should appear in the scoreboard",
@@ -303,10 +290,8 @@ class GameScreenTest {
 
     @Test
     fun score_history_button_appears_after_first_round_is_completed() {
-        // The History button only appears once at least one round has been recorded.
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()
-        // IconButton — findable by its contentDescription.
         composeTestRule.onNodeWithContentDescription("History").assertIsDisplayed()
     }
 
@@ -321,27 +306,24 @@ class GameScreenTest {
     @Test
     fun back_button_on_history_screen_returns_to_game() {
         launchGame()
-        composeTestRule.onNodeWithText("Skip round").performClick()  // complete round 1
+        composeTestRule.onNodeWithText("Skip round").performClick()
         composeTestRule.onNodeWithContentDescription("History").performClick()
         composeTestRule
             .onNodeWithContentDescription("Back to game")
             .performClick()
-        // We should be back on round 2's contract selection screen.
         composeTestRule.onNodeWithText("Round 2").assertIsDisplayed()
     }
 
     @Test
     fun score_history_button_also_appears_in_round_details_form() {
-        // After round 1 is done, entering step 2 should also show the History button.
         launchGame()
-        composeTestRule.onNodeWithText("Skip round").performClick()  // complete round 1
-        composeTestRule.onNodeWithText("Garde").performClick()        // enter step 2
+        composeTestRule.onNodeWithText("Skip round").performClick()
+        composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithContentDescription("History").assertIsDisplayed()
     }
 
     @Test
     fun partner_selector_not_shown_for_3_player_game() {
-        // Partner selection is only for 5-player games.
         launchGame(playerNames = listOf("Alice", "Bob", "Charlie"))
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("Partner (called by taker)").assertDoesNotExist()
@@ -349,19 +331,15 @@ class GameScreenTest {
 
     @Test
     fun partner_selector_is_shown_for_5_player_game() {
-        // In a 5-player game the partner selector must appear in the details form.
         launchGame(playerNames = listOf("Alice", "Bob", "Charlie", "Dave", "Eve"))
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("Partner (called by taker)").assertIsDisplayed()
     }
 
     // ── Spec: End Game button (bottom bar) ────────────────────────────────────
-    // End Game is now a text button in the persistent bottom action bar,
-    // so it is visible at all times regardless of which step the user is on.
 
     @Test
     fun end_game_button_is_displayed_on_step_1_from_the_start() {
-        // "End Game" must be visible in the bottom bar even before any round is played.
         launchGame()
         composeTestRule.onNodeWithText("End Game").assertIsDisplayed()
     }
@@ -375,7 +353,6 @@ class GameScreenTest {
 
     @Test
     fun end_game_button_is_displayed_on_step_2() {
-        // End Game remains visible in the bottom bar while the details form is open.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("End Game").assertIsDisplayed()
@@ -398,13 +375,11 @@ class GameScreenTest {
 
     @Test
     fun back_to_game_button_on_final_score_screen_returns_to_game() {
-        // Complete one round so there is a score to show, then end the game.
         launchGame()
-        composeTestRule.onNodeWithText("Skip round").performClick()  // complete round 1
+        composeTestRule.onNodeWithText("Skip round").performClick()
         composeTestRule.onNodeWithText("End Game").performClick()
         composeTestRule.onNodeWithText("Game Over").assertIsDisplayed()
 
-        // Tapping "Back to game" should return to the active round.
         composeTestRule.onNodeWithText("Back to game").performClick()
         composeTestRule.onNodeWithText("Round 2").assertIsDisplayed()
     }
@@ -416,24 +391,18 @@ class GameScreenTest {
         composeTestRule
             .onNodeWithContentDescription("Back to game")
             .performClick()
-        // Should be back at round 1 contract selection.
         composeTestRule.onNodeWithText("Round 1").assertIsDisplayed()
     }
 
     // ── Spec: points field validation (issue #8) ──────────────────────────────
-    // The user must not be able to enter a value outside 0–91.
-    // Entering a value > 91 shows an error message and disables the Confirm button.
 
     @Test
     fun entering_value_above_91_shows_error_message() {
-        // Open the details form so the points field is visible.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
-        // Type an out-of-range value (92) into the points field.
         composeTestRule.onNodeWithTag("points_input").performTextInput("92")
 
-        // The error string defined in EnStrings.pointsOutOfRange should appear.
         composeTestRule
             .onNodeWithText(EnStrings.pointsOutOfRange)
             .assertIsDisplayed()
@@ -444,10 +413,8 @@ class GameScreenTest {
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
-        // Type 99 — clearly out of range.
         composeTestRule.onNodeWithTag("points_input").performTextInput("99")
 
-        // Confirm button must be disabled so the round cannot be submitted.
         composeTestRule.onNodeWithText("Confirm round").assertIsNotEnabled()
     }
 
@@ -456,7 +423,6 @@ class GameScreenTest {
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
-        // 91 is the maximum allowed value — it must not trigger an error.
         composeTestRule.onNodeWithTag("points_input").performTextInput("91")
 
         composeTestRule
@@ -475,67 +441,46 @@ class GameScreenTest {
     }
 
     // ── Spec: styled round history rows (issue #6) ────────────────────────────
-    // Each history row must have a colored indicator dot whose testTag encodes
-    // the outcome: "round_indicator_won", "round_indicator_lost",
-    // or "round_indicator_skipped".
 
     @Test
     fun skipped_round_shows_skipped_indicator() {
-        // A skipped round must display the grey (skipped) indicator dot.
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()
-
-        // The indicator tagged "round_indicator_skipped" must be visible.
         composeTestRule.onNodeWithTag("round_indicator_skipped").assertIsDisplayed()
     }
 
     @Test
     fun lost_round_shows_lost_indicator() {
-        // Default form values: 0 bouts, 0 points → taker needs 56 to win → Lost.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("Confirm round").performClick()
-
-        // The indicator tagged "round_indicator_lost" must be visible.
         composeTestRule.onNodeWithTag("round_indicator_lost").assertIsDisplayed()
     }
 
     @Test
     fun won_round_shows_won_indicator() {
-        // 3 bouts, 91 points → needs only 36 → Won.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
-        // Select 3 bouts from the dropdown.
         composeTestRule.onNodeWithTag("bouts_dropdown").performClick()
         composeTestRule.onAllNodesWithText("3")[0].performClick()
 
-        // Enter a winning score (91 pts with 3 bouts → 91 ≥ 36 → Won).
         composeTestRule.onNodeWithTag("points_input").performTextInput("91")
 
         composeTestRule.onNodeWithText("Confirm round").performClick()
 
-        // The indicator tagged "round_indicator_won" must be visible.
         composeTestRule.onNodeWithTag("round_indicator_won").assertIsDisplayed()
     }
 
     // ── Spec: bonus label cell is fully tappable (issue #36) ─────────────────
-    // Tapping anywhere on the bonus label row (text or icon) must open the
-    // tooltip — not only the small ⓘ icon.
 
     @Test
     fun tapping_bonus_label_text_shows_tooltip() {
-        // Open the round-details form where the bonus grid is visible.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
-        // The "Petit" label is the first row of the compact bonus grid.
-        // Compose merges the semantics of the clickable Row so that the Text
-        // content ("Petit") is reachable as a clickable node.
         composeTestRule.onNodeWithText("Petit").performClick()
 
-        // After tapping, the tooltip body text must appear on screen.
-        // We use substring=true because the body contains a newline character.
         composeTestRule
             .onNodeWithText(EnStrings.petitTooltipBody, substring = true)
             .assertIsDisplayed()
@@ -543,14 +488,11 @@ class GameScreenTest {
 
     @Test
     fun tapping_bonus_label_shows_tooltip_title() {
-        // The RichTooltip heading must also be visible after the label is tapped.
         launchGame()
         composeTestRule.onNodeWithText("Garde").performClick()
 
         composeTestRule.onNodeWithText("Petit").performClick()
 
-        // The tooltip title is the bonus label itself — it should now appear
-        // inside the RichTooltip in addition to the label cell text.
         composeTestRule
             .onAllNodesWithText("Petit")
             .fetchSemanticsNodes()
@@ -564,7 +506,6 @@ class GameScreenTest {
 
     @Test
     fun multiple_rounds_show_correct_indicators() {
-        // Play one skipped + one lost round and verify both indicators appear.
         launchGame()
         composeTestRule.onNodeWithText("Skip round").performClick()   // round 1 → skipped
         composeTestRule.onNodeWithText("Garde").performClick()
@@ -575,44 +516,45 @@ class GameScreenTest {
     }
 
     // ── Spec: system back-button on game screen (issue #38) ───────────────────
-    // Pressing the Android system back button on the main game view (no overlay)
-    // should navigate directly to the landing page — no confirmation dialog.
 
     @Test
     fun pressing_system_back_on_game_screen_fires_onEndGame_callback() {
-        // Spec: back on the game screen → landing page (no dialog, immediate navigation).
         var endGameCalled = false
+        val viewModel = GameViewModel(
+            ApplicationProvider.getApplicationContext<Application>(),
+            FakeGameStorage()
+        )
+        viewModel.initGame(players, inProgressGame = null)
         composeTestRule.setContent {
             TarotCounterTheme {
-                // Wire onEndGame so we can verify the callback is called.
                 GameScreen(
-                    playerNames = players,
-                    onEndGame   = { endGameCalled = true }
+                    viewModel = viewModel,
+                    onEndGame = { endGameCalled = true }
                 )
             }
         }
-        // Espresso.pressBack() triggers the system back button.
-        // BackHandler (enabled = !showFinalScore, which starts as false) intercepts it.
         Espresso.pressBack()
         assertTrue("System back on game screen should call onEndGame", endGameCalled)
     }
 
     @Test
     fun pressing_system_back_on_history_overlay_fires_onEndGame_callback() {
-        // Spec: back on the score-history overlay → landing page (no dialog).
         var endGameCalled = false
+        val viewModel = GameViewModel(
+            ApplicationProvider.getApplicationContext<Application>(),
+            FakeGameStorage()
+        )
+        viewModel.initGame(players, inProgressGame = null)
         composeTestRule.setContent {
             TarotCounterTheme {
                 GameScreen(
-                    playerNames = players,
-                    onEndGame   = { endGameCalled = true }
+                    viewModel = viewModel,
+                    onEndGame = { endGameCalled = true }
                 )
             }
         }
-        // Open the history overlay by tapping the "History" button.
         composeTestRule.onNodeWithText("History").performClick()
-        // Back should still go to landing page, not back to game screen.
         Espresso.pressBack()
         assertTrue("System back on history overlay should call onEndGame", endGameCalled)
     }
-}}
+}

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -4,55 +4,41 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Card
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
-import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -63,73 +49,43 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import java.util.UUID
-import kotlinx.coroutines.launch
 
 // GameScreen handles the full round-by-round flow of a Tarot game on a single scrollable page.
 //
 // All information is presented together: the compact scoreboard, the contract selection,
-// and — once a contract is chosen — the scoring details form. There is no separate
-// step 2 screen; everything lives in one scrollable column.
+// and — once a contract is chosen — the scoring details form.
 //
-// playerNames:      the list of players set up on the previous screen.
-// inProgressGame:   if non-null, the screen restores from this saved state instead of
-//                   starting fresh (used when the user taps "Resume" on the setup screen).
-// onSaveProgress:   called after every completed or skipped round with the current state.
-//                   The caller (MainActivity) forwards this to GameViewModel which persists it.
-// onSaveGame:       called with the completed game data when the user taps "End Game".
-//                   Saving happens at that moment — not when "New Game" is later pressed —
-//                   so the game is persisted even if the app is closed on the Final Score screen.
-// onEndGame:        called when the user presses "New Game"; navigates back to the setup screen.
-// modifier:         passed in from the parent (e.g. Scaffold padding).
-@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
+// The screen observes game state from [GameViewModel] (currentRound, roundHistory, etc.)
+// and delegates all state-mutating actions to the ViewModel (recordPlayed, recordSkipped,
+// endGame). This separation means the game logic can be unit-tested without Compose.
+//
+// viewModel : holds the mutable game session state and all game-logic helpers.
+// onEndGame : called when the user presses "New Game" on the Final Score screen.
+//             The caller (MainActivity) uses this to navigate back to the setup screen.
+// modifier  : passed in from the parent (e.g. Scaffold padding).
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun GameScreen(
-    playerNames: List<String>,
-    inProgressGame: InProgressGame? = null,
-    onSaveProgress: (InProgressGame) -> Unit = {},
-    onSaveGame: (SavedGame) -> Unit = {},
+    viewModel: GameViewModel,
     onEndGame: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     // Read the active locale from the composition tree and resolve all strings once.
-    val locale = LocalAppLocale.current
+    val locale  = LocalAppLocale.current
     val strings = appStrings(locale)
 
-    // Stable UUID for this game session, used as SavedGame.id when the game is ended.
-    //
-    // Generating the ID here (once, via `remember`) rather than inside `endGame()` ensures
-    // that calling `endGame()` multiple times — e.g. pressing "End Game" again after
-    // navigating back from the Final Score screen — always produces the same ID.
-    // GameStorage then treats a repeated save as an upsert (update) rather than an insert,
-    // preventing duplicate entries in the history list.
-    //
-    // When resuming a saved game the stored `gameId` is reused so that the resumed game
-    // updates the same history entry it would have created if ended the first time.
-    // Old InProgressGame entries that predate this field will have gameId == ""; in that
-    // case we generate a fresh UUID to ensure the ID is always a valid, non-empty string.
-    val gameId = remember {
-        inProgressGame?.gameId?.ifBlank { UUID.randomUUID().toString() }
-            ?: UUID.randomUUID().toString()
-    }
-
-    // Current round number — restored from the saved state when resuming, otherwise 1.
-    var currentRound by remember { mutableIntStateOf(inProgressGame?.currentRound ?: 1) }
-
-    // The index of the player who takes first. Restored when resuming so the rotation
-    // continues seamlessly; chosen randomly for a fresh game.
-    val startingIndex = remember { inProgressGame?.startingIndex ?: playerNames.indices.random() }
-
-    // Observable list of completed rounds — populated from the saved state when resuming.
-    val roundHistory = remember {
-        mutableStateListOf<RoundResult>().apply {
-            inProgressGame?.rounds?.let { addAll(it) }
-        }
-    }
+    // Read game session state from the ViewModel.
+    // These are Compose snapshot values — recomposition is triggered automatically
+    // when the ViewModel mutates them (e.g. after recordPlayed() advances currentRound).
+    val currentRound  = viewModel.currentRound
+    val roundHistory  = viewModel.roundHistory
+    val displayNames  = viewModel.displayNames
+    val currentTaker  = viewModel.currentTaker
 
     // The contract selected by tapping one of the contract chips.
     // null = no contract selected yet (details form is hidden).
-    // non-null = a contract chip is active and the details form is shown below it.
+    // Non-null = a contract chip is active and the details form is shown below.
+    // This is pure UI state (not game logic) so it lives in the composable.
     var selectedContract by remember { mutableStateOf<Contract?>(null) }
 
     // Controls whether the score history table overlay is shown.
@@ -138,90 +94,14 @@ fun GameScreen(
     // Controls whether the final score screen overlay is shown.
     var showFinalScore by remember { mutableStateOf(false) }
 
-    // Returns the display name for a player: their typed name, or the localized
-    // fallback (e.g. "Player 1" in English, "Joueur 1" in French) if blank.
-    fun displayName(index: Int): String =
-        playerNames[index].ifBlank { strings.playerFallback(index + 1) }
-
-    // Derive the current taker from the starting index and the round number.
-    val currentTakerIndex = (startingIndex + currentRound - 1) % playerNames.size
-    val currentTaker = displayName(currentTakerIndex)
-
-    // Resolve all display names once so both the scoreboard and form use the same list.
-    val displayNames = playerNames.indices.map { displayName(it) }
-
-    // Builds an InProgressGame snapshot from the current game state.
-    // `gameId` is included so that if the game is resumed later, the same ID is
-    // carried through to the final SavedGame (preventing duplicate history entries).
-    fun progressSnapshot() = InProgressGame(
-        gameId        = gameId,
-        playerNames   = displayNames,
-        currentRound  = currentRound,
-        startingIndex = startingIndex,
-        rounds        = roundHistory.toList()
-    )
-
-    // Records a played round (contract + details) and advances to the next round.
-    fun recordPlayed(contract: Contract, details: RoundDetails) {
-        val won = takerWon(details.bouts, details.points)
-        val roundScore = calculateRoundScore(contract, details.bouts, details.points)
-        val baseScores = computePlayerScores(
-            allPlayers  = displayNames,
-            takerName   = currentTaker,
-            partnerName = details.partnerName,
-            won         = won,
-            roundScore  = roundScore
-        )
-        val numDefenders = if (details.partnerName != null) 3 else displayNames.size - 1
-        val scores = applyBonuses(baseScores, contract, details, currentTaker, won, numDefenders)
-        roundHistory.add(RoundResult(currentRound, currentTaker, contract, details, won, scores))
-        currentRound++
-        selectedContract = null   // collapse the details form for the next round
-        onSaveProgress(progressSnapshot())
-    }
-
-    // Records a skipped round (no contract, no details) and advances.
-    fun recordSkipped() {
-        roundHistory.add(RoundResult(currentRound, currentTaker, contract = null, details = null, won = null))
-        currentRound++
-        selectedContract = null
-        onSaveProgress(progressSnapshot())
-    }
-
-    // Saves the completed game and shows the Final Score screen.
-    //
-    // Uses the stable `gameId` (generated once in `remember` above) rather than a
-    // freshly generated UUID so that repeated calls — e.g. the user presses "End Game"
-    // again after navigating back — always produce the same SavedGame.id.
-    // GameStorage's upsert logic will then replace the existing history entry instead
-    // of inserting a duplicate.
-    fun endGame() {
-        if (roundHistory.isNotEmpty()) {
-            val savedGame = SavedGame(
-                id          = gameId,
-                datestamp   = System.currentTimeMillis(),
-                playerNames = displayNames,
-                rounds      = roundHistory.toList(),
-                finalScores = computeFinalTotals(displayNames, roundHistory)
-            )
-            onSaveGame(savedGame)
-        }
-        showFinalScore = true
-    }
-
     // ── System back-button handling ───────────────────────────────────────────
-    // BackHandler intercepts the Android system back button (gesture or hardware key).
-    //
-    // A single handler covers both the main game view and the score-history overlay:
-    // pressing back on either navigates directly to the landing page (no dialog).
-    //
-    // `enabled = !showFinalScore` disables this handler when the Final Score screen
-    // is visible — that composable registers its own BackHandler (deeper in the
-    // Compose tree, therefore higher priority) which shows a confirmation dialog first.
+    // A single handler covers both the main game view and the score-history overlay.
+    // `enabled = !showFinalScore` defers to the Final Score screen's own handler when
+    // that overlay is visible (deeper handlers have higher priority in Compose).
     BackHandler(enabled = !showFinalScore) { onEndGame() }
 
     // ── Overlay screens ───────────────────────────────────────────────────────
-    // These replace the whole content when active. The main game column is not rendered.
+    // These replace the whole content when active; the main game column is not rendered.
 
     if (showFinalScore) {
         FinalScoreScreen(
@@ -246,14 +126,11 @@ fun GameScreen(
 
     // ── Single-page game layout ───────────────────────────────────────────────
     // Everything lives in one scrollable column so the user always sees the scoreboard,
-    // the contract chips, and — when a contract is selected — the details form, all
+    // the contract chips, and — when a contract is selected — the details form,
     // without navigating away.
-    //
-    // imePadding() shrinks the scrollable area when the keyboard opens (used for the
-    // points text field), preventing the keyboard from covering content.
 
-    // Outer non-scrolling column: owns imePadding() so the entire layout
-    // (scrollable content + bottom bar) shifts above the keyboard as a unit.
+    // Outer non-scrolling column: owns imePadding() so the entire layout (scrollable
+    // content + bottom bar) shifts above the keyboard as a unit.
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -269,7 +146,7 @@ fun GameScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
 
-            // ── Header: history button | centred round number ────────────────────
+            // ── Header: history button | centred round number ────────────────
             // Box lets us layer two Rows: one for the side buttons (SpaceBetween)
             // and one for the centered title, so the title is truly centered
             // regardless of the buttons' widths.
@@ -303,7 +180,7 @@ fun GameScreen(
                 }
             }
 
-            // ── Compact scoreboard ────────────────────────────────────────────────
+            // ── Compact scoreboard ────────────────────────────────────────────
             // Shown after the first round so the user always has the current standings
             // in view without leaving the page.
             if (roundHistory.isNotEmpty()) {
@@ -319,11 +196,10 @@ fun GameScreen(
             HorizontalDivider()
             Spacer(Modifier.height(12.dp))
 
-            // ── Contract selection ────────────────────────────────────────────────
+            // ── Contract selection ────────────────────────────────────────────
             // SingleChoiceSegmentedButtonRow is the Material 3 standard for picking
-            // one option from a fixed set. Each segment gets equal width automatically,
-            // and the connected pill shape makes the active selection obvious.
-            // Tapping the already-selected segment deselects it (collapses the form).
+            // one option from a fixed set. Tapping the already-selected segment
+            // deselects it (collapses the details form).
             Text(
                 text = strings.chooseContract(currentTaker),
                 style = MaterialTheme.typography.titleMedium,
@@ -347,14 +223,12 @@ fun GameScreen(
                         ),
                         selected = selectedContract == c,
                         onClick  = { selectedContract = if (selectedContract == c) null else c },
-                        // Hide the checkmark icon so only the label is shown — the
-                        // filled/outlined segment already communicates selection clearly.
+                        // Hide the checkmark icon — the filled/outlined segment already
+                        // communicates selection clearly.
                         icon     = {}
                     ) {
                         AutoSizeText(
                             text            = c.localizedName(locale),
-                            // 2 dp keeps the label away from rounded corners without
-                            // eating into the already-tight segment width.
                             modifier        = Modifier.padding(horizontal = 1.dp),
                             sharedSizeState = contractLabelSize
                         )
@@ -364,71 +238,57 @@ fun GameScreen(
 
             Spacer(Modifier.height(8.dp))
 
-
-            // ── Inline round details ──────────────────────────────────────────────
-            // key(selectedContract) is a Compose primitive that discards and recreates
-            // everything inside it whenever selectedContract changes. This automatically
-            // resets bouts, points, and all the bonus state to their defaults whenever
-            // the user picks a different contract — no manual reset needed.
+            // ── Inline round details ──────────────────────────────────────────
+            // key(selectedContract) discards and recreates everything inside it
+            // whenever selectedContract changes, automatically resetting all form
+            // state (bouts, points, bonuses) without manual reset logic.
             key(selectedContract) {
                 val contract = selectedContract
                 if (contract != null) {
 
-                    // ── Form state ────────────────────────────────────────────────
-                    // Declared inside key() so they are reset when the contract changes.
-                    var bouts         by remember { mutableIntStateOf(0) }
-                    var pointsText    by remember { mutableStateOf("") }
-                    // When true the user enters the defenders' points instead of the taker's.
-                    // The taker's points are derived on submit: takerPoints = 91 − defenderPoints.
-                    var defenderMode  by remember { mutableStateOf(false) }
+                    // ── Form state ────────────────────────────────────────────
+                    // Declared inside key() so they reset when the contract changes.
+                    var bouts            by remember { mutableIntStateOf(0) }
+                    var pointsText       by remember { mutableStateOf("") }
+                    // When true the user enters the defenders' points; taker's points
+                    // are derived on submit as: takerPoints = 91 − defenderPoints.
+                    var defenderMode     by remember { mutableStateOf(false) }
                     var selectedPartner  by remember { mutableStateOf<String?>(null) }
-                    var petitAuBout   by remember { mutableStateOf<String?>(null) }
-                    var poignee       by remember { mutableStateOf<String?>(null) }
-                    var doublePoignee by remember { mutableStateOf<String?>(null) }
-                    var triplePoignee by remember { mutableStateOf<String?>(null) }
-                    var chelem        by remember { mutableStateOf(Chelem.NONE) }
-                    // The player who called/achieved the chelem. Reset to null whenever chelem
-                    // changes back to NONE (no chelem in this round).
-                    var chelemPlayer  by remember { mutableStateOf<String?>(null) }
+                    var petitAuBout      by remember { mutableStateOf<String?>(null) }
+                    var poignee          by remember { mutableStateOf<String?>(null) }
+                    var doublePoignee    by remember { mutableStateOf<String?>(null) }
+                    var triplePoignee    by remember { mutableStateOf<String?>(null) }
+                    var chelem           by remember { mutableStateOf(Chelem.NONE) }
+                    // The player who called/achieved the chelem; reset to null when
+                    // chelem reverts to NONE.
+                    var chelemPlayer     by remember { mutableStateOf<String?>(null) }
 
-                    // Derived error flag — recomputed on every recomposition when pointsText changes.
-                    // True only when the typed value parses to an integer that exceeds 91.
-                    // An empty field is not an error (it defaults to 0 on Confirm).
-                    // Declared here (not inside the Column) so both the TextField and the
-                    // Confirm button can read the same value.
+                    // Derived error flag — true when pointsText parses to an int > 91.
+                    // An empty field is not an error (defaults to 0 on Confirm).
                     val pointsError = pointsText.toIntOrNull()?.let { it > 91 } == true
 
-                    // Used to hide the software keyboard when the user taps "Done" on
-                    // the numeric keyboard after entering the points value.
+                    // Used to hide the software keyboard when the user taps "Done".
                     val keyboardController = LocalSoftwareKeyboardController.current
 
                     Spacer(Modifier.height(12.dp))
                     HorizontalDivider()
                     Spacer(Modifier.height(12.dp))
 
-                    // ── Bouts + Points side by side ───────────────────────────────
-                    // Placing these in a Row cuts one section of vertical space compared
-                    // to stacking them, helping everything fit on one screen.
-                    // Alignment.Bottom ensures both halves share the same bottom edge,
-                    // so the dropdown and the text field line up visually (issue #23).
+                    // ── Bouts + Points side by side ───────────────────────────
+                    // Placing these in a Row cuts vertical space compared to stacking them.
+                    // Alignment.Bottom keeps the dropdown and text field on the same baseline.
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.spacedBy(16.dp),
                         verticalAlignment = Alignment.Bottom
                     ) {
-                        // Left half: bouts dropdown
-                        // Replaced from FilterChips to an ExposedDropdownMenuBox to save
-                        // screen space and improve UX (issue #9).
+                        // Left half: bouts dropdown (ExposedDropdownMenuBox)
                         Column(modifier = Modifier.weight(1f)) {
                             FormLabel(strings.numberOfBouts)
                             Spacer(Modifier.height(8.dp))
 
-                            // Tracks whether the dropdown menu is currently open.
                             var boutsExpanded by remember { mutableStateOf(false) }
 
-                            // ExposedDropdownMenuBox is a Material3 combo box:
-                            // - The text field shows the current selection and a trailing arrow.
-                            // - Tapping it opens a menu with the four options (0–3).
                             ExposedDropdownMenuBox(
                                 expanded         = boutsExpanded,
                                 onExpandedChange = { boutsExpanded = !boutsExpanded },
@@ -438,13 +298,11 @@ fun GameScreen(
                                     value          = bouts.toString(),
                                     onValueChange  = {},
                                     readOnly       = true,
-                                    // The trailing chevron icon flips when the menu opens.
                                     trailingIcon   = {
                                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = boutsExpanded)
                                     },
                                     colors         = ExposedDropdownMenuDefaults.outlinedTextFieldColors(),
                                     singleLine     = true,
-                                    // menuAnchor() links the text field to its popup menu.
                                     modifier       = Modifier
                                         .menuAnchor(MenuAnchorType.PrimaryNotEditable)
                                         .fillMaxWidth()
@@ -456,24 +314,24 @@ fun GameScreen(
                                     // One menu item per valid bout count (0 through 3).
                                     for (n in 0..3) {
                                         DropdownMenuItem(
-                                            text             = { Text(n.toString()) },
-                                            onClick          = {
+                                            text           = { Text(n.toString()) },
+                                            onClick        = {
                                                 bouts         = n
                                                 boutsExpanded = false
                                             },
-                                            contentPadding   = ExposedDropdownMenuDefaults.ItemContentPadding
+                                            contentPadding = ExposedDropdownMenuDefaults.ItemContentPadding
                                         )
                                     }
                                 }
                             }
                         }
-                        // Right half: points entry — segmented toggle stacked above text field
+
+                        // Right half: points entry — camp toggle stacked above text field
                         Column(modifier = Modifier.weight(1f)) {
-                            // ── Camp toggle ────────────────────────────────────────
+                            // ── Camp toggle ────────────────────────────────────
                             // The two segments let the user pick which camp's points to type.
-                            // Selecting "Defenders" is a convenience — the taker's points are
-                            // derived on confirm as: takerPoints = 91 − defenderPoints.
-                            // `fillMaxWidth` makes the toggle use the same width as the field below.
+                            // Selecting "Defenders" is a convenience; taker points are derived
+                            // on confirm as: takerPoints = 91 − defenderPoints.
                             SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                                 SegmentedButton(
                                     selected = !defenderMode,
@@ -482,14 +340,8 @@ fun GameScreen(
                                         pointsText   = ""  // clear field when switching camps
                                     },
                                     shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                                    // Remove the default checkmark icon so the label has more space.
-                                    // Selection is still indicated by the filled background color.
                                     icon  = {}
                                 ) {
-                                    // AutoSizeText shrinks the font automatically so long labels
-                                    // (e.g. French "Attaquant") always fit inside the button.
-                                    // padding(horizontal = 4.dp) adds an inner margin so the text
-                                    // never touches the button's rounded corners.
                                     AutoSizeText(
                                         strings.attackerMode,
                                         modifier = Modifier.padding(horizontal = 4.dp)
@@ -502,8 +354,6 @@ fun GameScreen(
                                         pointsText   = ""  // clear field when switching camps
                                     },
                                     shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                                    // Remove the default checkmark icon for consistency with the
-                                    // attacker button — color alone conveys the selected state.
                                     icon  = {}
                                 ) {
                                     AutoSizeText(
@@ -515,8 +365,7 @@ fun GameScreen(
                             OutlinedTextField(
                                 value = pointsText,
                                 onValueChange = { input ->
-                                    // Accept only digit characters and at most two of them
-                                    // (the highest valid value, 91, has two digits).
+                                    // Accept only digit characters, at most two (max value 91).
                                     if (input.all { it.isDigit() } && input.length <= 2) {
                                         pointsText = input
                                     }
@@ -528,12 +377,9 @@ fun GameScreen(
                                 keyboardActions = KeyboardActions(
                                     onDone = { keyboardController?.hide() }
                                 ),
-                                // Show the valid range directly in the placeholder so the
-                                // user knows what values are accepted without wasting vertical
-                                // space on a separate supporting-text hint.
+                                // Show the valid range as a placeholder so the user knows
+                                // what values are accepted without a separate hint.
                                 placeholder     = { Text("0-91") },
-                                // When the value is out of range, mark the field red and
-                                // show a descriptive error message below it.
                                 isError         = pointsError,
                                 supportingText  = if (pointsError) ({
                                     Text(
@@ -542,7 +388,6 @@ fun GameScreen(
                                     )
                                 }) else null,
                                 singleLine      = true,
-                                // testTag lets UI tests identify and interact with this field.
                                 modifier        = Modifier.fillMaxWidth().testTag("points_input")
                             )
                         }
@@ -552,9 +397,8 @@ fun GameScreen(
                     HorizontalDivider()
                     Spacer(Modifier.height(12.dp))
 
-                    // ── Partner selection (5-player only) ─────────────────────────
+                    // ── Partner selection (5-player only) ─────────────────────
                     // In a 5-player game the taker calls a silent partner before the round.
-                    // The partner's identity affects how the round score is distributed.
                     if (displayNames.size == 5) {
                         val partnerOptions = displayNames.filter { it != currentTaker }
                         PlayerChipSelector(
@@ -569,9 +413,7 @@ fun GameScreen(
                         Spacer(Modifier.height(16.dp))
                     }
 
-                    // ── Player-assigned bonuses (compact grid) ─────────────────────
-                    // Each row has a label + ⓘ info icon that shows a tooltip explaining
-                    // the bonus and its point value.
+                    // ── Player-assigned bonuses (compact grid) ─────────────────
                     CompactBonusGrid(
                         playerNames     = displayNames,
                         bonusLabels     = listOf(
@@ -596,13 +438,7 @@ fun GameScreen(
                     HorizontalDivider()
                     Spacer(Modifier.height(12.dp))
 
-                    // ── Chelem (grand slam) ────────────────────────────────────────
-                    // The dropdown is self-labelled: it shows "Chelem" when nothing is
-                    // selected (Chelem.NONE) and the chosen outcome's name otherwise.
-                    // This removes the need for a separate section header above the field.
-                    // The ⓘ tooltip icon is placed immediately to the right of the dropdown.
-
-                    // Tracks whether the chelem dropdown menu is open.
+                    // ── Chelem (grand slam) ────────────────────────────────────
                     var chelemExpanded by remember { mutableStateOf(false) }
 
                     Row(
@@ -610,8 +446,6 @@ fun GameScreen(
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                         modifier              = Modifier.fillMaxWidth()
                     ) {
-                        // ExposedDropdownMenuBox is the Material 3 combo-box pattern (same as bouts).
-                        // weight(1f) lets it fill the row minus the ⓘ icon space.
                         ExposedDropdownMenuBox(
                             expanded         = chelemExpanded,
                             onExpandedChange = { chelemExpanded = !chelemExpanded },
@@ -620,8 +454,7 @@ fun GameScreen(
                                 .testTag("chelem_dropdown")
                         ) {
                             OutlinedTextField(
-                                // Show the placeholder "Chelem" when no outcome is selected,
-                                // or the chosen outcome's name when one is active.
+                                // Show the placeholder "Chelem" when no outcome is selected.
                                 value         = if (chelem == Chelem.NONE)
                                                     strings.chelemPlaceholder
                                                 else
@@ -645,8 +478,8 @@ fun GameScreen(
                                     DropdownMenuItem(
                                         text           = { Text(c.localizedName(locale)) },
                                         onClick        = {
-                                            // When the user picks a new chelem option, reset the
-                                            // associated player — the previous selection is no longer valid.
+                                            // Reset the associated player when a different
+                                            // chelem option is selected.
                                             if (chelem != c) chelemPlayer = null
                                             chelem         = c
                                             chelemExpanded = false
@@ -663,21 +496,13 @@ fun GameScreen(
                         )
                     }
 
-                    // ── Chelem player selector ─────────────────────────────────────
-                    // Only shown when a non-NONE chelem outcome is selected. The user picks
-                    // which player called or achieved the chelem — this player leads the first
-                    // trick of the round, overriding the usual turn order.
-                    //
-                    // Available choices: taker + partner (5-player only). In 3/4-player games
-                    // only the taker can call chelem, so the selector is still shown to make the
-                    // association explicit, but the partner option is omitted.
+                    // ── Chelem player selector ─────────────────────────────────
+                    // Only shown when a non-NONE chelem outcome is selected.
                     if (chelem != Chelem.NONE) {
                         Spacer(Modifier.height(8.dp))
-                        // The eligible players are the taker and — in 5-player — the partner.
                         val chelemCandidates = buildList {
                             add(currentTaker)
-                            // In a 5-player game the partner (if chosen) can also call chelem.
-                            // Using ?.let avoids a force-unwrap while preserving the same logic.
+                            // In a 5-player game the partner can also call chelem.
                             if (displayNames.size == 5) selectedPartner?.let { add(it) }
                         }
                         PlayerChipSelector(
@@ -688,7 +513,6 @@ fun GameScreen(
                             onSelect       = { chelemPlayer = it }
                         )
                         // Informational note: the chelem caller plays first this round.
-                        // This reminder is shown only when a specific player has been selected.
                         if (chelemPlayer != null &&
                             (chelem == Chelem.ANNOUNCED_REALIZED || chelem == Chelem.ANNOUNCED_NOT_REALIZED)) {
                             Spacer(Modifier.height(4.dp))
@@ -702,55 +526,46 @@ fun GameScreen(
 
                     Spacer(Modifier.height(16.dp))
 
-                    // ── Confirm / back ─────────────────────────────────────────────
+                    // ── Confirm ────────────────────────────────────────────────
                     AppButton(
                         text    = strings.confirmRound,
-                        // Disabled while the points field shows an error so the user cannot
-                        // submit an out-of-range value.
                         enabled = !pointsError,
                         modifier = Modifier.fillMaxWidth(0.8f),
                         onClick = {
                             // Parse the typed points; default to 0 if empty, clamp to 0–91.
                             val enteredPoints = pointsText.toIntOrNull()?.coerceIn(0, 91) ?: 0
-                            // When the user counted the defenders' points, convert to taker's points.
-                            // The total points in a round always sum to 91:
-                            //   takerPoints = 91 − defenderPoints
+                            // When the user entered defenders' points, convert to taker's points.
                             val points = if (defenderMode) 91 - enteredPoints else enteredPoints
-                            recordPlayed(
+                            viewModel.recordPlayed(
                                 contract,
                                 RoundDetails(
                                     bouts         = bouts,
                                     points        = points,
-                                    // partnerName is only meaningful in 5-player games.
                                     partnerName   = if (displayNames.size == 5) selectedPartner else null,
                                     petitAuBout   = petitAuBout,
                                     poignee       = poignee,
                                     doublePoignee = doublePoignee,
                                     triplePoignee = triplePoignee,
                                     chelem        = chelem,
-                                    // chelemPlayer is null when chelem == NONE.
                                     chelemPlayer  = if (chelem == Chelem.NONE) null else chelemPlayer
                                 )
                             )
+                            // Collapse the details form so the next round starts fresh.
+                            selectedContract = null
                         }
                     )
-
                 }
             }
 
-            // ── Round history ─────────────────────────────────────────────────────
-            // Displayed below the form so the full game log is always a single scroll away.
-            // Shown newest-first so the most recent result is at the top of this section.
+            // ── Round history (newest-first) ──────────────────────────────────
             if (roundHistory.isNotEmpty()) {
                 Spacer(Modifier.height(24.dp))
                 HorizontalDivider()
                 Spacer(Modifier.height(12.dp))
 
-                // reversed() so the latest round appears first (newest-first order).
                 val reversedHistory = roundHistory.reversed()
                 reversedHistory.forEachIndexed { index, round ->
                     RoundHistoryRow(round = round, locale = locale, strings = strings)
-                    // Draw a thin divider between rows (but not after the last one).
                     if (index < reversedHistory.lastIndex) {
                         HorizontalDivider(
                             modifier  = Modifier.padding(vertical = 4.dp),
@@ -762,9 +577,8 @@ fun GameScreen(
             }
         }  // end inner scrollable Column
 
-        // ── Bottom action bar ─────────────────────────────────────────────────────
-        // Persistent split row pinned below the scroll area. weight(1f) on each
-        // button gives them exactly equal widths.
+        // ── Bottom action bar ─────────────────────────────────────────────────
+        // Persistent split row pinned below the scroll area.
         HorizontalDivider()
         Row(
             modifier = Modifier
@@ -775,13 +589,16 @@ fun GameScreen(
             // Left half: end the game and navigate to the Final Score screen.
             AppOutlinedButton(
                 text     = strings.endGame,
-                onClick  = { endGame() },
+                onClick  = {
+                    viewModel.endGame()
+                    showFinalScore = true
+                },
                 modifier = Modifier.weight(1f)
             )
             // Right half: record a skipped round and advance to the next.
             AppButton(
                 text     = strings.skipRound,
-                onClick  = { recordSkipped() },
+                onClick  = { viewModel.recordSkipped() },
                 modifier = Modifier.weight(1f)
             )
         }
@@ -791,16 +608,14 @@ fun GameScreen(
 // ── Compact scoreboard ────────────────────────────────────────────────────────
 
 // Displays all players and their cumulative scores in a compact horizontal card.
-// Each player gets a column: their name on top and their current total below.
-// This is always visible at the top of the game page — no separate History screen needed.
+// Each player gets a column: their name on top, their running total below.
+// Always visible at the top of the game page after the first round.
 @Composable
 private fun CompactScoreboard(
     displayNames: List<String>,
     roundHistory: List<RoundResult>,
     scoresLabel: String
 ) {
-    // The label is required by the spec and checked by tests.
-    // fillMaxWidth() makes the text span the card width, so it aligns left naturally.
     Text(
         text  = scoresLabel,
         style = MaterialTheme.typography.titleSmall,
@@ -808,7 +623,6 @@ private fun CompactScoreboard(
     )
     Spacer(Modifier.height(4.dp))
 
-    // Card gives the scoreboard a visible background and subtle elevation.
     Card(modifier = Modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier
@@ -826,14 +640,12 @@ private fun CompactScoreboard(
                         text     = name,
                         style    = MaterialTheme.typography.labelMedium,
                         maxLines = 1,
-                        // Ellipsize long names so the row stays on one line.
                         overflow = TextOverflow.Ellipsis
                     )
                     Text(
                         text  = "$sign$total",
                         style = MaterialTheme.typography.titleMedium,
-                        // Green for positive/zero scores, red for negative — makes
-                        // standings readable at a glance without reading the numbers.
+                        // Green for positive/zero scores, red for negative.
                         color = scoreColor(total)
                     )
                 }
@@ -845,15 +657,13 @@ private fun CompactScoreboard(
 // ── Shared composables ────────────────────────────────────────────────────────
 
 // An icon-only button with a bar-chart icon for opening the score history overlay.
-// Using IconButton (no text) keeps the header compact; the contentDescription
-// ensures screen readers still announce the purpose of the button.
+// The contentDescription ensures screen readers announce the button's purpose.
 @Composable
 fun HistoryButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
     val strings = appStrings(LocalAppLocale.current)
     IconButton(onClick = onClick, modifier = modifier) {
         Icon(
             imageVector        = Icons.Default.BarChart,
-            // Accessible label read by TalkBack — same text that was previously the button label.
             contentDescription = strings.history
         )
     }
@@ -865,24 +675,19 @@ fun HistoryButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
 //
 // Layout:  [●]  Round N: Taker — Contract · details — Outcome
 //
-// The leading dot (●) is colored by outcome so the user can scan results at a
-// glance without reading the text:
-//   Won     → MaterialTheme.colorScheme.primary   (green)
+// The leading dot (●) is colored by outcome so the user can scan results at a glance:
+//   Won     → MaterialTheme.colorScheme.primary   (green in default theme)
 //   Lost    → MaterialTheme.colorScheme.error     (red)
-//   Skipped → MaterialTheme.colorScheme.onSurfaceVariant (muted grey)
+//   Skipped → MaterialTheme.colorScheme.onSurfaceVariant (muted)
 //
-// All colors come from Material theme tokens — never hardcoded hex values —
-// so they automatically adapt to light vs. dark mode.
-//
-// The `testTag` on the indicator dot lets UI tests assert the correct color
-// semantic without reading color values directly.
+// The `testTag` on the dot lets UI tests assert the correct outcome without
+// reading color values directly.
 @Composable
 private fun RoundHistoryRow(
     round:   RoundResult,
     locale:  AppLocale,
     strings: AppStrings
 ) {
-    // ── Build text segments ────────────────────────────────────────────────
     val contractText = round.contract?.localizedName(locale) ?: strings.skipped
     val detailsText  = round.details?.let {
         strings.boutsPointsDetail(it.bouts, it.points)
@@ -900,292 +705,30 @@ private fun RoundHistoryRow(
         null  -> ""
     }
 
-    // ── Choose indicator color and test tag by outcome ─────────────────────
-    // `Pair<Color, String>` groups the color token with the test tag so
-    // the when expression is compact and both values stay in sync.
     val (indicatorColor, indicatorTag) = when (round.won) {
-        true  -> MaterialTheme.colorScheme.primary         to "round_indicator_won"
-        false -> MaterialTheme.colorScheme.error           to "round_indicator_lost"
+        true  -> MaterialTheme.colorScheme.primary          to "round_indicator_won"
+        false -> MaterialTheme.colorScheme.error            to "round_indicator_lost"
         null  -> MaterialTheme.colorScheme.onSurfaceVariant to "round_indicator_skipped"
     }
 
-    // ── Row: indicator dot + history text ──────────────────────────────────
     Row(
         modifier          = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.Top
     ) {
-        // Colored ● indicator — the key visual cue for won/lost/skipped.
-        // `bodyMedium` matches the text size so the dot aligns with the
-        // first line of the history text.
         Text(
             text     = "●  ",
             style    = MaterialTheme.typography.bodyMedium,
             color    = indicatorColor,
             modifier = Modifier.testTag(indicatorTag)
         )
-
-        // Main history text — same content as before, now on the right of the dot.
-        // `weight(1f)` lets the text wrap naturally without pushing the dot away.
         Text(
             text     = strings.roundHistoryPrefix(round.roundNumber, round.takerName) +
                        contractText + detailsText + outcomeText,
             style    = MaterialTheme.typography.bodyMedium,
-            // Prevent very long player names or bonus lists from causing layout overflow.
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f)
         )
     }
 }
-
-// ── Form helpers ──────────────────────────────────────────────────────────────
-
-// A small bold label placed above a form section inside the details area.
-// `private` limits its scope to this file.
-@Composable
-private fun FormLabel(text: String) {
-    Text(
-        text  = text,
-        style = MaterialTheme.typography.titleSmall,
-        modifier = Modifier.fillMaxWidth()
-    )
-}
-
-// Holds the display data and state callbacks for one row of the bonus grid.
-// Declared at file scope (not inside the composable) so it is not recreated on
-// every recomposition of CompactBonusGrid.
-private data class BonusRow(
-    val label: String,
-    val tooltip: String,
-    val value: String?,
-    val onSelect: (String?) -> Unit
-)
-
-// Compact bonus grid: shows four player-assigned bonuses as a table.
-//
-// Layout:
-//   Row 0 (header):  empty label | Player1 | Player2 | …
-//   Row 1–4 (data):  label + ⓘ  | ☑/☐    | ☑/☐    | …
-//
-// Each player cell holds a Checkbox. Ticking it assigns that player;
-// ticking the already-checked player clears the assignment (sets to null).
-// The ⓘ icon sits immediately to the right of each label text and opens a
-// RichTooltip explaining the bonus and its point value.
-//
-// `bonusLabels`   : four localized label strings (parallel to the state params).
-// `bonusTooltips` : four tooltip body strings shown when the ⓘ is tapped.
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun CompactBonusGrid(
-    playerNames: List<String>,
-    bonusLabels: List<String>,
-    bonusTooltips: List<String>,
-    petitAuBout: String?,     onPetit: (String?) -> Unit,
-    poignee: String?,         onPoignee: (String?) -> Unit,
-    doublePoignee: String?,   onDoublePoignee: (String?) -> Unit,
-    triplePoignee: String?,   onTriplePoignee: (String?) -> Unit
-) {
-    // Zip labels + tooltips + state pairs into one list for the grid loop.
-    val bonuses = listOf(
-        BonusRow(bonusLabels[0], bonusTooltips[0], petitAuBout,   onPetit),
-        BonusRow(bonusLabels[1], bonusTooltips[1], poignee,        onPoignee),
-        BonusRow(bonusLabels[2], bonusTooltips[2], doublePoignee,  onDoublePoignee),
-        BonusRow(bonusLabels[3], bonusTooltips[3], triplePoignee,  onTriplePoignee)
-    )
-
-    // Number of selectable options = one per player (nobody column removed).
-    val colCount    = playerNames.size
-    // Slightly wider label column to accommodate the label text + ⓘ icon.
-    val labelWeight = 0.42f
-    // Each option column gets an equal share of the remaining width.
-    val colWeight   = (1f - labelWeight) / colCount
-
-    Column(modifier = Modifier.fillMaxWidth()) {
-
-        // ── Header row: column titles ─────────────────────────────────────────
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            // Empty space over the label column.
-            Spacer(Modifier.weight(labelWeight))
-            // One header per player (nobody/— column removed).
-            for (name in playerNames) {
-                Text(
-                    text      = name,
-                    style     = MaterialTheme.typography.labelSmall,
-                    maxLines  = 1,
-                    overflow  = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.Center,
-                    modifier  = Modifier.weight(colWeight)
-                )
-            }
-        }
-
-        // ── One row per bonus ─────────────────────────────────────────────────
-        for (row in bonuses) {
-            Row(
-                // heightIn(min = 48.dp) enforces Material's recommended minimum touch-target
-                // height, making the radio buttons easier to tap on small screens.
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(min = 48.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                // Label column: same weight-based sizing as before so checkboxes stay
-                // aligned. BonusLabelCell sits inside and only makes the text+icon
-                // tappable — the surrounding empty space in the column is not clickable.
-                Row(
-                    modifier = Modifier.weight(labelWeight),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    BonusLabelCell(label = row.label, body = row.tooltip)
-                }
-
-                // One Checkbox per player.
-                // Ticking an unchecked box assigns that player; ticking an already-checked
-                // box clears the assignment (sets value back to null).
-                for (name in playerNames) {
-                    Checkbox(
-                        checked         = row.value == name,
-                        onCheckedChange = { checked ->
-                            row.onSelect(if (checked) name else null)
-                        },
-                        modifier = Modifier.weight(colWeight)
-                    )
-                }
-            }
-        }
-    }
-}
-
-// Shows a "None" chip followed by one chip per player.
-// Tapping a player assigns that player to the bonus; tapping the selected
-// player again (or "None") clears the assignment.
-//
-// label:          localized section header text.
-// noneLabel:      localized label for the "nobody" option chip.
-// selectedPlayer: the currently assigned player name, or null if nobody is assigned.
-// onSelect:       called with the new player name, or null to clear.
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun PlayerChipSelector(
-    label: String,
-    noneLabel: String,
-    selectedPlayer: String?,
-    playerNames: List<String>,
-    onSelect: (String?) -> Unit
-) {
-    FormLabel(label)
-    Spacer(Modifier.height(8.dp))
-    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        FilterChip(
-            selected = selectedPlayer == null,
-            onClick  = { onSelect(null) },
-            label    = { Text(noneLabel) }
-        )
-        for (name in playerNames) {
-            // Tapping the already-selected player deselects them (null = nobody).
-            FilterChip(
-                selected = selectedPlayer == name,
-                onClick  = { onSelect(if (selectedPlayer == name) null else name) },
-                label    = { Text(name) }
-            )
-        }
-    }
-}
-
-// ── Bonus label cell (label + ⓘ icon, fully tappable) ────────────────────────
-//
-// Wraps the entire label cell — bonus name text and the decorative ⓘ icon — in a
-// single TooltipBox so tapping anywhere on the row opens the description tooltip.
-// This gives a much larger touch target than a standalone icon button.
-//
-// label : localized bonus name; shown as text and as the tooltip title.
-// body  : multi-line tooltip body (rules + point value).
-//
-// Layout note: this composable is intentionally content-sized (no fillMaxWidth).
-// The enclosing Row in CompactBonusGrid carries the weight() modifier that
-// determines the label column width, keeping checkboxes properly aligned.
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun BonusLabelCell(label: String, body: String) {
-    val tooltipState = rememberTooltipState(isPersistent = true)
-    val scope        = rememberCoroutineScope()
-
-    TooltipBox(
-        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
-        tooltip = {
-            // RichTooltip supports a title and a multi-line body text.
-            RichTooltip(title = { Text(label) }) {
-                Text(body)
-            }
-        },
-        state = tooltipState
-    ) {
-        // Only text + icon are clickable — the empty space in the label column is not.
-        Row(
-            modifier = Modifier.clickable { scope.launch { tooltipState.show() } },
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text     = label,
-                style    = MaterialTheme.typography.bodySmall,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            // Decorative info icon — the clickable Row above handles all input.
-            Icon(
-                imageVector        = Icons.Default.Info,
-                contentDescription = null,
-                tint               = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier           = Modifier
-                    .padding(start = 2.dp)
-                    .size(14.dp)
-            )
-        }
-    }
-}
-
-// ── Bonus tooltip icon (Chelem section) ───────────────────────────────────────
-//
-// A small ⓘ IconButton that shows a Material3 RichTooltip on tap.
-// Used next to the Chelem dropdown header.
-//
-// title : the bonus name shown as the tooltip heading.
-// body  : multi-line explanation text (rules + point value) shown below the title.
-//
-// The tooltip is set as `isPersistent = true` so it stays open until the user
-// dismisses it — important on mobile where there is no hover event to close it.
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun BonusInfoIcon(title: String, body: String) {
-    val tooltipState = rememberTooltipState(isPersistent = true)
-    val scope        = rememberCoroutineScope()
-
-    TooltipBox(
-        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
-        tooltip = {
-            // RichTooltip supports a title and a multi-line body text.
-            RichTooltip(title = { Text(title) }) {
-                Text(body)
-            }
-        },
-        state = tooltipState
-    ) {
-        // Small icon button — 20 dp keeps it compact inside the label column.
-        IconButton(
-            onClick  = { scope.launch { tooltipState.show() } },
-            modifier = Modifier.size(20.dp)
-        ) {
-            Icon(
-                imageVector        = Icons.Default.Info,
-                contentDescription = null,
-                tint               = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier           = Modifier.size(14.dp)
-            )
-        }
-    }
-}
-

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameViewModel.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameViewModel.kt
@@ -1,8 +1,13 @@
 package fr.mandarine.tarotcounter
 
 import android.app.Application
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import java.util.UUID
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -73,6 +78,133 @@ class GameViewModel internal constructor(
             started      = SharingStarted.WhileSubscribed(5_000),
             initialValue = null
         )
+
+    // ── Game session state ────────────────────────────────────────────────────
+    //
+    // These fields are set by initGame() and mutated by recordPlayed(), recordSkipped(),
+    // and endGame(). Living here (rather than inside the GameScreen composable) lets the
+    // three action methods be tested on the JVM without a running Compose tree.
+
+    // Stable identifier for the current game session — reused if the game is ended
+    // multiple times (e.g. after navigating back from Final Score) so GameStorage
+    // treats repeated saves as upserts instead of duplicates.
+    private var _gameId: String = ""
+
+    // Index into _displayNames of the player who took first in round 1.
+    // Used to restore the taker-rotation formula correctly after a resume.
+    private var _startingIndex: Int = 0
+
+    // Resolved display names for this session (typed name or locale fallback).
+    // Set once by initGame(); does not change during the session.
+    private var _displayNames: List<String> = emptyList()
+
+    // Observable round counter. `mutableIntStateOf` is a Compose snapshot primitive:
+    // any composable that reads `currentRound` automatically recomposes when it changes.
+    // `private set` prevents callers from mutating it directly.
+    var currentRound by mutableIntStateOf(1)
+        private set
+
+    // Observable round history. `mutableStateListOf` notifies Compose when items are
+    // added, so the history list and scoreboard recompose automatically after each round.
+    val roundHistory = mutableStateListOf<RoundResult>()
+
+    // Read-only accessors — GameScreen reads these but must not write them directly.
+    val displayNames: List<String> get() = _displayNames
+    val startingIndex: Int get() = _startingIndex
+    val gameId: String get() = _gameId
+
+    // The display name of the player who takes in the current round.
+    // Derived from _startingIndex and currentRound so it updates automatically
+    // when currentRound (a snapshot state) changes during composition.
+    val currentTaker: String
+        get() {
+            if (_displayNames.isEmpty()) return ""
+            val index = (_startingIndex + currentRound - 1) % _displayNames.size
+            return _displayNames[index]
+        }
+
+    // Initializes (or restores) a game session.
+    //
+    // displayNames : resolved player names — blank entries must have been replaced
+    //               by the caller (e.g. "Player 1") before passing them in.
+    // inProgressGame : non-null when resuming a saved game; null for a fresh start.
+    fun initGame(displayNames: List<String>, inProgressGame: InProgressGame?) {
+        _displayNames  = displayNames
+        _gameId        = inProgressGame?.gameId?.ifBlank { UUID.randomUUID().toString() }
+                            ?: UUID.randomUUID().toString()
+        _startingIndex = inProgressGame?.startingIndex ?: displayNames.indices.random()
+        currentRound   = inProgressGame?.currentRound ?: 1
+        roundHistory.clear()
+        inProgressGame?.rounds?.let { roundHistory.addAll(it) }
+    }
+
+    // Records a completed round (contract + details), advances the round counter,
+    // and persists the updated in-progress snapshot to DataStore.
+    //
+    // All scoring logic runs here — previously these calculations lived inside the
+    // GameScreen composable as a local `fun recordPlayed()`, which meant they were
+    // recreated on every recomposition and could not be unit-tested.
+    fun recordPlayed(contract: Contract, details: RoundDetails) {
+        val taker    = currentTaker
+        val won      = takerWon(details.bouts, details.points)
+        val score    = calculateRoundScore(contract, details.bouts, details.points)
+        val base     = computePlayerScores(
+            allPlayers  = _displayNames,
+            takerName   = taker,
+            partnerName = details.partnerName,
+            won         = won,
+            roundScore  = score
+        )
+        // 3/4-player: every non-taker is a defender; 5-player: exactly 3 defenders.
+        val numDef   = if (details.partnerName != null) 3 else _displayNames.size - 1
+        val scores   = applyBonuses(base, contract, details, taker, won, numDef)
+        roundHistory.add(RoundResult(currentRound, taker, contract, details, won, scores))
+        currentRound++
+        saveInProgressGame(buildProgressSnapshot())
+    }
+
+    // Records a skipped round (no contract selected), advances the round counter,
+    // and persists the updated in-progress snapshot.
+    fun recordSkipped() {
+        roundHistory.add(
+            RoundResult(
+                roundNumber = currentRound,
+                takerName   = currentTaker,
+                contract    = null,
+                details     = null,
+                won         = null
+            )
+        )
+        currentRound++
+        saveInProgressGame(buildProgressSnapshot())
+    }
+
+    // Saves the completed game to the history list (when at least one round was played).
+    // Calling saveGame() also clears the in-progress entry via saveGame()'s implementation.
+    // The caller (GameScreen) is responsible for navigating to the Final Score screen.
+    fun endGame() {
+        if (roundHistory.isNotEmpty()) {
+            saveGame(
+                SavedGame(
+                    id          = _gameId,
+                    datestamp   = System.currentTimeMillis(),
+                    playerNames = _displayNames,
+                    rounds      = roundHistory.toList(),
+                    finalScores = computeFinalTotals(_displayNames, roundHistory)
+                )
+            )
+        }
+    }
+
+    // Builds an InProgressGame snapshot from the current session state.
+    // Called after every recordPlayed/recordSkipped to keep DataStore in sync.
+    private fun buildProgressSnapshot() = InProgressGame(
+        gameId        = _gameId,
+        playerNames   = _displayNames,
+        currentRound  = currentRound,
+        startingIndex = _startingIndex,
+        rounds        = roundHistory.toList()
+    )
 
     // Saves the completed game to the past-games list and clears the in-progress state.
     //

--- a/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
@@ -79,15 +79,6 @@ class MainActivity : ComponentActivity() {
                     // `currentScreen` directly instead of `currentScreen.value`.
                     var currentScreen by remember { mutableStateOf(Screen.SETUP) }
 
-                    // The finalized player names passed to the game once "Start Game" is pressed
-                    // (or derived from the saved in-progress state when resuming).
-                    var confirmedPlayers by remember { mutableStateOf(listOf<String>()) }
-
-                    // The in-progress game to restore from, set when the user taps "Resume".
-                    // Null for a fresh game. Stored in `remember` so it survives recompositions
-                    // but is not persisted (the ViewModel's StateFlow is the authoritative source).
-                    var gameToResume by remember { mutableStateOf<InProgressGame?>(null) }
-
                     // Scaffold provides the basic Material Design page structure.
                     // It handles padding so our content doesn't go under system bars.
                     Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
@@ -97,19 +88,21 @@ class MainActivity : ComponentActivity() {
                                 modifier       = Modifier.padding(innerPadding),
                                 pastGames      = pastGames,
                                 inProgressGame = inProgressGame,
-                                // Start a fresh game: clear any leftover in-progress state so
-                                // the resume card does not appear after the new game starts.
-                                onStartGame = { names ->
-                                    confirmedPlayers = names
-                                    gameToResume = null
+                                // Start a fresh game: resolve display names (blank entries become
+                                // "Player N" / "Joueur N"), then initialize the ViewModel session.
+                                onStartGame = { rawNames ->
+                                    val appStrings = appStrings(currentLocale)
+                                    val resolvedNames = rawNames.mapIndexed { i, name ->
+                                        name.ifBlank { appStrings.playerFallback(i + 1) }
+                                    }
+                                    gameViewModel.initGame(resolvedNames, inProgressGame = null)
                                     gameViewModel.clearInProgressGame()
                                     currentScreen = Screen.GAME
                                 },
-                                // Resume the interrupted game: restore state and navigate directly
-                                // to GameScreen without going through the setup form.
+                                // Resume the interrupted game: the stored playerNames are already
+                                // resolved (they were saved by initGame on the previous session).
                                 onResumeGame = { game ->
-                                    confirmedPlayers = game.playerNames
-                                    gameToResume = game
+                                    gameViewModel.initGame(game.playerNames, game)
                                     currentScreen = Screen.GAME
                                 },
                                 // Persist the user's language choice and trigger a recomposition
@@ -119,20 +112,11 @@ class MainActivity : ComponentActivity() {
                                 onThemeChange  = { gameViewModel.setTheme(it) }
                             )
                             Screen.GAME -> GameScreen(
-                                playerNames     = confirmedPlayers,
-                                inProgressGame  = gameToResume,
-                                // Called after every round to keep DataStore in sync.
-                                onSaveProgress  = { game -> gameViewModel.saveInProgressGame(game) },
-                                // Called when the user presses "End Game" (before FinalScoreScreen).
-                                // saveGame() persists the completed entry and clears in-progress.
-                                onSaveGame      = { game -> gameViewModel.saveGame(game) },
+                                viewModel = gameViewModel,
                                 // Called when the user presses "New Game" on FinalScoreScreen.
                                 // The game is already saved at this point — just navigate away.
-                                onEndGame = {
-                                    gameToResume = null
-                                    currentScreen = Screen.SETUP
-                                },
-                                modifier = Modifier.padding(innerPadding)
+                                onEndGame = { currentScreen = Screen.SETUP },
+                                modifier  = Modifier.padding(innerPadding)
                             )
                         }
                     }

--- a/app/src/main/java/fr/mandarine/tarotcounter/UiComponents.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/UiComponents.kt
@@ -1,19 +1,48 @@
 package fr.mandarine.tarotcounter
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableFloatState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared UI building blocks for the whole app.
@@ -195,5 +224,249 @@ fun AppTextButton(
 ) {
     TextButton(onClick = onClick, modifier = modifier, enabled = enabled) {
         AutoSizeText(text)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reusable game-form building blocks
+//
+// These composables were originally private inside GameScreen.kt. Moving them
+// here makes them available to any screen that needs them and lets them be
+// tested and maintained without touching the main game-screen file.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// A small bold label placed above a form section.
+// `fillMaxWidth()` ensures the label stretches to align with the field below it.
+@Composable
+fun FormLabel(text: String) {
+    Text(
+        text  = text,
+        style = MaterialTheme.typography.titleSmall,
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+// Holds the display data and state callbacks for one row of the bonus grid.
+// Declared at file scope (not inside the composable) so it is not recreated on
+// every recomposition of [CompactBonusGrid].
+data class BonusRow(
+    val label: String,
+    val tooltip: String,
+    val value: String?,
+    val onSelect: (String?) -> Unit
+)
+
+// A label cell that wraps both a bonus name and a decorative ⓘ icon inside a
+// single [TooltipBox] so that tapping anywhere on the cell opens the description.
+//
+// label : localized bonus name — shown as text and as the tooltip title.
+// body  : multi-line tooltip body (rules + point value).
+//
+// Layout note: this composable is intentionally content-sized (no fillMaxWidth).
+// The enclosing Row in [CompactBonusGrid] carries the weight() modifier that
+// determines the label column width, keeping checkboxes properly aligned.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BonusLabelCell(label: String, body: String) {
+    val tooltipState = rememberTooltipState(isPersistent = true)
+    val scope        = rememberCoroutineScope()
+
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+        tooltip = {
+            // RichTooltip supports a title and a multi-line body text.
+            RichTooltip(title = { Text(label) }) {
+                Text(body)
+            }
+        },
+        state = tooltipState
+    ) {
+        // Only the text + icon are clickable — empty space in the label column is not.
+        Row(
+            modifier = Modifier.clickable { scope.launch { tooltipState.show() } },
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text     = label,
+                style    = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            // Decorative info icon — the clickable Row above handles all input.
+            Icon(
+                imageVector        = Icons.Default.Info,
+                contentDescription = null,
+                tint               = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier           = Modifier
+                    .padding(start = 2.dp)
+                    .size(14.dp)
+            )
+        }
+    }
+}
+
+// A small ⓘ [IconButton] that opens a [RichTooltip] when tapped.
+// Used next to standalone dropdowns (e.g. the Chelem dropdown in the round form)
+// where a full [BonusLabelCell] would not fit.
+//
+// title : the bonus name shown as the tooltip heading.
+// body  : multi-line explanation text (rules + point value).
+//
+// `isPersistent = true` keeps the tooltip open until the user dismisses it —
+// important on mobile where there is no hover event to close it automatically.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BonusInfoIcon(title: String, body: String) {
+    val tooltipState = rememberTooltipState(isPersistent = true)
+    val scope        = rememberCoroutineScope()
+
+    TooltipBox(
+        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+        tooltip = {
+            RichTooltip(title = { Text(title) }) {
+                Text(body)
+            }
+        },
+        state = tooltipState
+    ) {
+        // Small icon button — 20 dp keeps it compact inside a row.
+        IconButton(
+            onClick  = { scope.launch { tooltipState.show() } },
+            modifier = Modifier.size(20.dp)
+        ) {
+            Icon(
+                imageVector        = Icons.Default.Info,
+                contentDescription = null,
+                tint               = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier           = Modifier.size(14.dp)
+            )
+        }
+    }
+}
+
+// Compact grid showing four player-assigned bonuses (petit au bout, poignée,
+// double poignée, triple poignée).
+//
+// Layout:
+//   Row 0 (header):  empty label column | Player1 | Player2 | …
+//   Row 1–4 (data):  label + ⓘ          | ☑/☐    | ☑/☐    | …
+//
+// Each player cell holds a [Checkbox]. Ticking an unchecked box assigns that
+// player; ticking the already-checked player clears the assignment (null).
+//
+// bonusLabels   : four localized label strings (parallel to the state params).
+// bonusTooltips : four tooltip body strings shown when the ⓘ is tapped.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CompactBonusGrid(
+    playerNames: List<String>,
+    bonusLabels: List<String>,
+    bonusTooltips: List<String>,
+    petitAuBout: String?,     onPetit: (String?) -> Unit,
+    poignee: String?,         onPoignee: (String?) -> Unit,
+    doublePoignee: String?,   onDoublePoignee: (String?) -> Unit,
+    triplePoignee: String?,   onTriplePoignee: (String?) -> Unit
+) {
+    // Zip labels + tooltips + state pairs into one list for the grid loop.
+    val bonuses = listOf(
+        BonusRow(bonusLabels[0], bonusTooltips[0], petitAuBout,   onPetit),
+        BonusRow(bonusLabels[1], bonusTooltips[1], poignee,        onPoignee),
+        BonusRow(bonusLabels[2], bonusTooltips[2], doublePoignee,  onDoublePoignee),
+        BonusRow(bonusLabels[3], bonusTooltips[3], triplePoignee,  onTriplePoignee)
+    )
+
+    // The label column is slightly wider to accommodate the text + ⓘ icon.
+    val labelWeight = 0.42f
+    // Each player column gets an equal share of the remaining width.
+    val colWeight   = (1f - labelWeight) / playerNames.size
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+
+        // ── Header row: one column title per player ───────────────────────────
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Empty space above the label column.
+            Spacer(Modifier.weight(labelWeight))
+            for (name in playerNames) {
+                Text(
+                    text      = name,
+                    style     = MaterialTheme.typography.labelSmall,
+                    maxLines  = 1,
+                    overflow  = TextOverflow.Ellipsis,
+                    modifier  = Modifier.weight(colWeight)
+                )
+            }
+        }
+
+        // ── One row per bonus ─────────────────────────────────────────────────
+        for (row in bonuses) {
+            Row(
+                // heightIn(min = 48.dp) enforces Material's recommended minimum
+                // touch-target height, making checkboxes easier to tap on small screens.
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 48.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // Label column: BonusLabelCell makes the text + icon tappable;
+                // empty space in the weight-based column is not clickable.
+                Row(
+                    modifier = Modifier.weight(labelWeight),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    BonusLabelCell(label = row.label, body = row.tooltip)
+                }
+
+                // One Checkbox per player. Ticking an unchecked box assigns
+                // that player; ticking the already-checked player clears it.
+                for (name in playerNames) {
+                    Checkbox(
+                        checked         = row.value == name,
+                        onCheckedChange = { checked ->
+                            row.onSelect(if (checked) name else null)
+                        },
+                        modifier = Modifier.weight(colWeight)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// Shows a "None" chip followed by one chip per player name.
+// Tapping a player assigns them to the bonus; tapping the selected player
+// again (or "None") clears the selection.
+//
+// label          : localized section header text shown above the chips.
+// noneLabel      : localized label for the "nobody" chip.
+// selectedPlayer : the currently assigned player name, or null if nobody.
+// onSelect       : callback with the new player name, or null to clear.
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun PlayerChipSelector(
+    label: String,
+    noneLabel: String,
+    selectedPlayer: String?,
+    playerNames: List<String>,
+    onSelect: (String?) -> Unit
+) {
+    FormLabel(label)
+    Spacer(Modifier.height(8.dp))
+    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        FilterChip(
+            selected = selectedPlayer == null,
+            onClick  = { onSelect(null) },
+            label    = { Text(noneLabel) }
+        )
+        for (name in playerNames) {
+            // Tapping the already-selected player deselects them (null = nobody).
+            FilterChip(
+                selected = selectedPlayer == name,
+                onClick  = { onSelect(if (selectedPlayer == name) null else name) },
+                label    = { Text(name) }
+            )
+        }
     }
 }

--- a/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -357,5 +358,243 @@ class GameViewModelTest {
 
         assertEquals(AppTheme.DARK, collected.last())
         job.cancel()
+    }
+
+    // ── initGame ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun `initGame fresh game starts at round 1`() {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        assertEquals(1, vm.currentRound)
+    }
+
+    @Test
+    fun `initGame stores display names`() {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        val names = listOf("Alice", "Bob", "Charlie")
+
+        vm.initGame(names, inProgressGame = null)
+
+        assertEquals(names, vm.displayNames)
+    }
+
+    @Test
+    fun `initGame restores currentRound from inProgressGame`() {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        val saved = InProgressGame(
+            gameId        = "g1",
+            playerNames   = listOf("Alice", "Bob"),
+            currentRound  = 5,
+            startingIndex = 0,
+            rounds        = emptyList()
+        )
+
+        vm.initGame(saved.playerNames, saved)
+
+        assertEquals(5, vm.currentRound)
+    }
+
+    @Test
+    fun `initGame restores rounds from inProgressGame`() {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        val round = RoundResult(1, "Alice", contract = null, details = null, won = null)
+        val saved = InProgressGame(
+            gameId        = "g1",
+            playerNames   = listOf("Alice", "Bob"),
+            currentRound  = 2,
+            startingIndex = 0,
+            rounds        = listOf(round)
+        )
+
+        vm.initGame(saved.playerNames, saved)
+
+        assertEquals(1, vm.roundHistory.size)
+        assertEquals(round, vm.roundHistory[0])
+    }
+
+    @Test
+    fun `initGame clears previous session rounds`() {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        // First game: one skipped round.
+        vm.initGame(listOf("Alice", "Bob"), inProgressGame = null)
+        vm.recordSkipped()
+        assertEquals(1, vm.roundHistory.size)
+
+        // Second game: fresh start — history must be empty.
+        vm.initGame(listOf("Alice", "Bob"), inProgressGame = null)
+
+        assertEquals(0, vm.roundHistory.size)
+    }
+
+    // ── recordSkipped ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `recordSkipped advances currentRound`() = runTest {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.recordSkipped()
+
+        assertEquals(2, vm.currentRound)
+    }
+
+    @Test
+    fun `recordSkipped adds a skipped RoundResult to history`() = runTest {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.recordSkipped()
+
+        assertEquals(1, vm.roundHistory.size)
+        assertNull(vm.roundHistory[0].contract)
+        assertNull(vm.roundHistory[0].won)
+    }
+
+    @Test
+    fun `recordSkipped calls saveInProgressGame`() = runTest {
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.recordSkipped()
+
+        assertEquals(1, storage.saveInProgressCallCount)
+    }
+
+    // ── recordPlayed ──────────────────────────────────────────────────────────
+
+    /** Minimal [RoundDetails] suitable for use in recordPlayed tests. */
+    private fun basicDetails(bouts: Int = 0, points: Int = 0) = RoundDetails(
+        bouts         = bouts,
+        points        = points,
+        partnerName   = null,
+        petitAuBout   = null,
+        poignee       = null,
+        doublePoignee = null,
+        chelem        = Chelem.NONE
+    )
+
+    @Test
+    fun `recordPlayed advances currentRound`() = runTest {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.recordPlayed(Contract.GARDE, basicDetails())
+
+        assertEquals(2, vm.currentRound)
+    }
+
+    @Test
+    fun `recordPlayed adds a RoundResult with the correct contract`() = runTest {
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.recordPlayed(Contract.GARDE, basicDetails())
+
+        assertEquals(Contract.GARDE, vm.roundHistory[0].contract)
+    }
+
+    @Test
+    fun `recordPlayed marks result as Lost when points below threshold`() = runTest {
+        // 0 bouts → requires 56 pts; 0 < 56 → Lost.
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.recordPlayed(Contract.GARDE, basicDetails(bouts = 0, points = 0))
+
+        assertEquals(false, vm.roundHistory[0].won)
+    }
+
+    @Test
+    fun `recordPlayed marks result as Won when points meet threshold`() = runTest {
+        // 3 bouts → requires 36 pts; 91 >= 36 → Won.
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.recordPlayed(Contract.GARDE, basicDetails(bouts = 3, points = 91))
+
+        assertEquals(true, vm.roundHistory[0].won)
+    }
+
+    @Test
+    fun `recordPlayed calls saveInProgressGame`() = runTest {
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.recordPlayed(Contract.GARDE, basicDetails())
+
+        assertEquals(1, storage.saveInProgressCallCount)
+    }
+
+    @Test
+    fun `recordPlayed populates playerScores for all players`() = runTest {
+        val players = listOf("Alice", "Bob", "Charlie")
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        vm.initGame(players, inProgressGame = null)
+
+        vm.recordPlayed(Contract.GARDE, basicDetails(bouts = 0, points = 0))
+
+        // Every player should have a score entry (zero-sum game, so all 3 must be present).
+        val scores = vm.roundHistory[0].playerScores
+        players.forEach { name ->
+            assertTrue("$name should have a score entry", scores.containsKey(name))
+        }
+        // Tarot is zero-sum: the sum of all player scores for a round is always 0.
+        assertEquals(0, scores.values.sum())
+    }
+
+    // ── endGame ───────────────────────────────────────────────────────────────
+
+    @Test
+    fun `endGame saves a SavedGame when rounds exist`() = runTest {
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+        vm.recordSkipped()  // at least one round needed
+
+        vm.endGame()
+
+        assertEquals(1, storage.addGameCallCount)
+    }
+
+    @Test
+    fun `endGame does not save when no rounds have been played`() = runTest {
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+
+        vm.endGame()
+
+        assertEquals(0, storage.addGameCallCount)
+    }
+
+    @Test
+    fun `endGame saved game contains correct playerNames`() = runTest {
+        val players = listOf("Alice", "Bob", "Charlie")
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+        vm.initGame(players, inProgressGame = null)
+        vm.recordSkipped()
+
+        vm.endGame()
+
+        assertEquals(players, storage.lastAddedGame?.playerNames)
+    }
+
+    @Test
+    fun `endGame clears the in-progress game`() = runTest {
+        val storage = FakeGameStorage()
+        val vm = GameViewModel(Application(), storage)
+        vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
+        vm.recordSkipped()
+
+        vm.endGame()
+
+        // saveGame() (called by endGame()) also clears in-progress via the ViewModel.
+        assertEquals(1, storage.clearInProgressCallCount)
     }
 }

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -13,6 +13,17 @@ After setting up players on the setup screen, the user taps **Start Game** to be
 
 ### Game Screen (`GameScreen`)
 
+`GameScreen` is a thin UI layer: it observes state from `GameViewModel` and calls ViewModel methods for all game actions. All scoring logic lives in the ViewModel, making it unit-testable without Compose.
+
+**Responsibilities split:**
+
+| Concern | Where it lives |
+|---|---|
+| Game session state (`currentRound`, `roundHistory`) | `GameViewModel` |
+| `recordPlayed`, `recordSkipped`, `endGame` | `GameViewModel` |
+| Contract selection, overlay visibility | `GameScreen` (local `remember` state) |
+| Sub-composables (`CompactBonusGrid`, `PlayerChipSelector`, etc.) | `UiComponents.kt` |
+
 The game is divided into **rounds**. The taker for each round is determined automatically:
 
 - **Round 1** — a random player is chosen as the first taker.

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -112,6 +112,87 @@ SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
 
 ---
 
+## FormLabel
+
+```kotlin
+@Composable
+fun FormLabel(text: String)
+```
+
+A small bold label placed above a form section (e.g. above the bouts dropdown or the bonus grid). Uses `MaterialTheme.typography.titleSmall` and fills the available width.
+
+```kotlin
+FormLabel(strings.numberOfBouts)
+```
+
+---
+
+## BonusInfoIcon
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BonusInfoIcon(title: String, body: String)
+```
+
+A small ⓘ `IconButton` (20 dp) that opens a `RichTooltip` when tapped. Use it next to standalone dropdowns where a full label row would not fit (e.g. next to the Chelem dropdown in the round form). The tooltip is persistent — it stays open until the user dismisses it.
+
+```kotlin
+BonusInfoIcon(title = strings.chelemLabel, body = strings.chelemTooltipBody)
+```
+
+---
+
+## BonusLabelCell
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BonusLabelCell(label: String, body: String)
+```
+
+A tappable cell showing a bonus name followed by a small ⓘ icon. Tapping anywhere on the cell opens a `RichTooltip` explaining the bonus. Used as the label column in `CompactBonusGrid`. Content-sized — the enclosing `Row` carries the weight modifier.
+
+---
+
+## CompactBonusGrid
+
+```kotlin
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CompactBonusGrid(
+    playerNames: List<String>,
+    bonusLabels: List<String>,
+    bonusTooltips: List<String>,
+    petitAuBout: String?,     onPetit: (String?) -> Unit,
+    poignee: String?,         onPoignee: (String?) -> Unit,
+    doublePoignee: String?,   onDoublePoignee: (String?) -> Unit,
+    triplePoignee: String?,   onTriplePoignee: (String?) -> Unit
+)
+```
+
+A compact grid showing four player-assigned bonuses (petit au bout, poignée, double poignée, triple poignée). The header row shows player names; each data row shows a bonus label + ⓘ on the left and one `Checkbox` per player on the right. Ticking a checked box clears the assignment (sets it back to `null`).
+
+---
+
+## PlayerChipSelector
+
+```kotlin
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun PlayerChipSelector(
+    label: String,
+    noneLabel: String,
+    selectedPlayer: String?,
+    playerNames: List<String>,
+    onSelect: (String?) -> Unit
+)
+```
+
+A `FlowRow` of `FilterChip`s — one "None" chip followed by one chip per player. Used for the partner selector (5-player games) and the chelem player selector. Tapping the already-selected player deselects them.
+
+---
+
 ## AppButton
 
 ```kotlin


### PR DESCRIPTION
## Summary

- Move reusable sub-composables (`FormLabel`, `BonusLabelCell`, `BonusInfoIcon`, `CompactBonusGrid`, `PlayerChipSelector`) from `GameScreen.kt` to `UiComponents.kt` — available app-wide, easy to find.
- Move game-state mutating helpers (`recordPlayed`, `recordSkipped`, `endGame`) to `GameViewModel` as proper methods. These were previously local functions inside the composable: recreated on every recomposition and untestable without Compose.
- `GameViewModel` now holds the full game session state (`currentRound`, `roundHistory`, `gameId`, `startingIndex`, `displayNames`) and exposes `initGame()`, called from `MainActivity` when a game starts or resumes.
- `GameScreen` becomes a thin UI layer: observes ViewModel state, delegates all game actions to the ViewModel. Local state limited to `selectedContract`, `showScoreHistory`, `showFinalScore`.

## Test plan

- [ ] Run `./gradlew testDebugUnitTest` — all unit tests pass (new tests cover `initGame`, `recordPlayed`, `recordSkipped`, `endGame`)
- [ ] Run `./gradlew lint` — no new warnings
- [ ] Run `./gradlew connectedAndroidTest` on a device/emulator — all `GameScreenTest` and other UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)