### PR TITLE
feat(68): support 10-inch tablets in landscape orientation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ app/src/main/java/fr/mandarine/tarotcounter/
 
 **Button convention**: never use raw `Button` / `OutlinedButton` / `TextButton` — always use `AppButton` / `AppOutlinedButton` / `AppTextButton` from `UiComponents.kt`. These wrappers automatically shrink labels to fit any screen width or translation length. See [`docs/ui-components.md`](docs/ui-components.md) for details.
 
+**Tablet & landscape support**: every screen wraps its content in a `Box(contentAlignment = TopCenter)` and constrains the inner column to `MAX_CONTENT_WIDTH = 600 dp` via `widthIn`. On phones the column fills the screen normally; on 10-inch tablets in landscape the content is centered with comfortable margins on each side.
+
 **Persistence**: completed games are saved to **DataStore** as JSON (via `kotlinx.serialization`). A `GameViewModel` holds the `StateFlow<List<SavedGame>>` that the setup screen observes.
 
 ## Tech Stack

--- a/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -128,9 +129,15 @@ fun FinalScoreScreen(
         .mapIndexedNotNull { i, name -> if (name in winners) i + 1 else null }
         .toSet()
 
+    // Box centers the content Column horizontally on wide screens (tablets in landscape).
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter
+    ) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
+        modifier = Modifier
+            .widthIn(max = MAX_CONTENT_WIDTH)
+            .fillMaxWidth()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
@@ -357,7 +364,8 @@ fun FinalScoreScreen(
             onClick  = onBack,
             modifier = Modifier.fillMaxWidth()
         )
-    }
+    }   // end Column
+    }   // end Box
 }
 
 /**

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -129,11 +131,23 @@ fun GameScreen(
     // the contract chips, and — when a contract is selected — the details form,
     // without navigating away.
 
+    // Box fills the entire screen and centers the game Column horizontally.
+    // On tablets in landscape the Column is capped at MAX_CONTENT_WIDTH and
+    // centered, preventing the form fields and scoreboard from stretching
+    // uncomfortably wide.
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter
+    ) {
     // Outer non-scrolling column: owns imePadding() so the entire layout (scrollable
     // content + bottom bar) shifts above the keyboard as a unit.
+    // fillMaxHeight() is required so the inner weight(1f) column and the
+    // pinned bottom bar share available vertical space correctly.
     Column(
-        modifier = modifier
-            .fillMaxSize()
+        modifier = Modifier
+            .widthIn(max = MAX_CONTENT_WIDTH)
+            .fillMaxWidth()
+            .fillMaxHeight()
             .imePadding()
     ) {
         // Inner scrollable column: weight(1f) takes all vertical space above
@@ -603,6 +617,7 @@ fun GameScreen(
             )
         }
     }  // end outer Column
+    }  // end Box
 }
 
 // ── Compact scoreboard ────────────────────────────────────────────────────────

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -39,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
@@ -87,14 +89,24 @@ fun LandingScreen(
     // Initialized with 3 empty strings matching the default player count.
     val playerNames = remember { mutableStateListOf("", "", "") }
 
+    // Box fills the whole screen and centers its child horizontally.
+    // This ensures the content Column is centered on wide screens (e.g. tablets in landscape)
+    // while still filling the entire width on small phones.
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter
+    ) {
     // Column stacks children vertically. `verticalScroll` makes it scrollable
     // in case the content (name fields + button) doesn't fit on smaller screens.
+    // `widthIn(max = MAX_CONTENT_WIDTH)` caps the column at 600 dp so it doesn't
+    //   stretch across a full 10-inch tablet screen.
     // `imePadding()` shrinks this Column by the keyboard height when the IME is open.
     // `Arrangement.Top` is the correct choice for scrollable columns: centering fights
     // with overflow and can clip content when the keyboard reduces the available height.
     Column(
-        modifier = modifier
-            .fillMaxSize()
+        modifier = Modifier
+            .widthIn(max = MAX_CONTENT_WIDTH)
+            .fillMaxWidth()
             .imePadding()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 32.dp),
@@ -319,7 +331,8 @@ fun LandingScreen(
                 AutoSizeText(text = strings.feedbackButton)
             }
         }
-    }
+    }   // end Column
+    }   // end Box
 }
 
 // ResumeGameCard is shown when there is an unfinished game saved from a previous session.
@@ -482,6 +495,16 @@ private fun PastGameCard(game: SavedGame, strings: AppStrings) {
 @Preview(showBackground = true)
 @Composable
 fun LandingScreenPreview() {
+    TarotCounterTheme {
+        LandingScreen()
+    }
+}
+
+// Tablet landscape preview — verifies that content is centered and not stretched
+// across the full width of a 10-inch tablet screen in landscape orientation.
+@Preview(showBackground = true, device = Devices.PIXEL_TABLET, widthDp = 1032, heightDp = 800)
+@Composable
+fun LandingScreenTabletLandscapePreview() {
     TarotCounterTheme {
         LandingScreen()
     }

--- a/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -67,9 +69,15 @@ fun ScoreHistoryScreen(
     // Read the active locale and resolve all strings once at the top of the composable.
     val strings = appStrings(LocalAppLocale.current)
 
+    // Box centers the content Column horizontally on wide screens (tablets in landscape).
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter
+    ) {
     Column(
-        modifier = modifier
-            .fillMaxSize()
+        modifier = Modifier
+            .widthIn(max = MAX_CONTENT_WIDTH)
+            .fillMaxWidth()
             // verticalScroll on the outer Column scrolls the entire page (header + table)
             // vertically, so long game histories never clip off-screen.
             .verticalScroll(rememberScrollState())
@@ -164,8 +172,9 @@ fun ScoreHistoryScreen(
                         .size(16.dp)
                 )
             }
-        }   // end Box
-    }
+        }   // end (inner table) Box
+    }   // end Column
+    }   // end (centering) Box
 }
 
 /**

--- a/app/src/main/java/fr/mandarine/tarotcounter/UiComponents.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/UiComponents.kt
@@ -52,6 +52,12 @@ import kotlinx.coroutines.launch
 //       button label automatically shrinks to fit its container.
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Maximum content width for all screens.
+// On large screens (e.g. 10-inch tablets in landscape) the content is constrained
+// to this width and centered horizontally so it never stretches uncomfortably wide.
+// 600 dp matches the Material Design "compact/medium" breakpoint guideline.
+internal val MAX_CONTENT_WIDTH = 600.dp
+
 /**
  * Returns a [MutableFloatState] to be shared across several [AutoSizeText] instances that sit
  * inside the same fixed-width row (e.g. [SingleChoiceSegmentedButtonRow]).

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -2,6 +2,36 @@
 
 All reusable UI building blocks live in `UiComponents.kt`.
 
+## MAX_CONTENT_WIDTH
+
+```kotlin
+internal val MAX_CONTENT_WIDTH = 600.dp
+```
+
+The maximum width used by every screen's content column. On large screens (10-inch tablets in landscape, ~960–1280 dp wide) the content is constrained to 600 dp and centered inside a `Box` so it never stretches uncomfortably wide.
+
+**Pattern used in each screen:**
+
+```kotlin
+Box(
+    modifier = modifier.fillMaxSize(),
+    contentAlignment = Alignment.TopCenter
+) {
+    Column(
+        modifier = Modifier
+            .widthIn(max = MAX_CONTENT_WIDTH)
+            .fillMaxWidth()
+            // … screen-specific scroll + padding modifiers
+    ) {
+        // screen content
+    }
+}
+```
+
+For `GameScreen` (which has a bottom action bar that must pin to the bottom), add `.fillMaxHeight()` after `.fillMaxWidth()`.
+
+---
+
 ## Rule: always use the App* button wrappers
 
 **Never use raw Material3 button composables directly.** Use the wrappers below instead so that every button label automatically shrinks to fit its container — no clipping, no wrapping, regardless of screen size or translation length.


### PR DESCRIPTION
## Summary

- Adds `MAX_CONTENT_WIDTH = 600 dp` constant in `UiComponents.kt` as the shared tablet breakpoint
- Wraps every screen's content column in a `Box(contentAlignment = TopCenter)` so it is centered on wide screens
- Applies `widthIn(max = MAX_CONTENT_WIDTH).fillMaxWidth()` to the inner Column on all four screens (Landing, Game, FinalScore, ScoreHistory)
- `GameScreen` additionally uses `.fillMaxHeight()` so the bottom action bar stays pinned while the scrollable area fills remaining space
- Adds a tablet landscape `@Preview` to `LandingScreen` for easy IDE validation
- Updates `docs/ui-components.md` and `README.md` with the new pattern

No new dependencies. No logic changes — pure layout constraint.

Closes #68

## Test plan

- [ ] Build passes (`./gradlew assembleDebug`)
- [ ] Unit tests pass (`./gradlew testDebugUnitTest`)
- [ ] Lint passes (`./gradlew lint`)
- [ ] Open the new `LandingScreenTabletLandscapePreview` in Android Studio — content should be centered with ~200 dp margins on each side
- [ ] Run on a Pixel Tablet emulator in landscape: all screens show centered content, no horizontal stretching
- [ ] Run on a Pixel 6 emulator: no visual difference from before (content still fills full width)

🤖 Generated with [Claude Code](https://claude.com/claude-code)