### PR TITLE
refactor(75): extract shared score table logic

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
@@ -4,8 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
-import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,17 +39,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import fr.mandarine.tarotcounter.ui.theme.GoldWinnerDark
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-
-// Width of the "Round" column — round numbers rarely exceed two digits.
-private val FINAL_ROUND_COL_WIDTH: Dp = 64.dp
-
-// Width of each player column — must fit score strings like "+1000" and names
-// up to about 8 characters.
-private val FINAL_PLAYER_COL_WIDTH: Dp = 80.dp
 
 /**
  * FinalScoreScreen shows the game results when the player ends the game early
@@ -274,50 +262,21 @@ fun FinalScoreScreen(
                 ) {
                 // Header row: localized "Round" label + one header per player name.
                 // No score values for the header row — labels use the default colour.
-                FinalScoreTableRow(
-                    cells = listOf(strings.roundColumn) + playerNames,
-                    isHeader = true,
+                ScoreTableRow(
+                    cells               = listOf(strings.roundColumn) + playerNames,
+                    isHeader            = true,
                     winnerColumnIndices = winnerColumnIndices
                 )
                 HorizontalDivider()
 
-                // Accumulate running totals the same way ScoreHistoryScreen does.
-                // We start every player at 0 and add their per-round delta on each iteration.
-                val runningTotals = playerNames.associateWith { 0 }.toMutableMap()
-
-                for (round in roundHistory) {
-                    // Add this round's contribution to each player's running total.
-                    // Skipped rounds have an empty `playerScores` map, so they add 0.
-                    for (name in playerNames) {
-                        runningTotals[name] =
-                            (runningTotals[name] ?: 0) + round.playerScores.getOrDefault(name, 0)
-                    }
-
-                    // Build the cell list: round number first, then cumulative score per player.
-                    val cells = buildList {
-                        add(round.roundNumber.toString())
-                        for (name in playerNames) {
-                            val total = runningTotals[name] ?: 0
-                            // Always show the sign so positive/negative is immediately clear.
-                            val sign = if (total >= 0) "+" else ""
-                            add("$sign$total")
-                        }
-                    }
-
-                    // Parallel list of raw score integers for colour coding.
-                    // Index 0 is null (round-number column); indices 1+ hold running totals.
-                    val scoreValues: List<Int?> = buildList {
-                        add(null) // round-number column — no colour
-                        for (name in playerNames) {
-                            add(runningTotals[name] ?: 0)
-                        }
-                    }
-
-                    FinalScoreTableRow(
-                        cells = cells,
-                        isHeader = false,
-                        winnerColumnIndices = winnerColumnIndices,
-                        scoreValues = scoreValues
+                // buildScoreTableData() (GameModels.kt) handles the running-totals
+                // accumulation loop — shared with ScoreHistoryScreen (issue #75).
+                for (row in buildScoreTableData(playerNames, roundHistory)) {
+                    ScoreTableRow(
+                        cells               = row.cells,
+                        isHeader            = false,
+                        scoreValues         = row.scoreValues,
+                        winnerColumnIndices = winnerColumnIndices
                     )
                 }
             }   // end Column
@@ -368,79 +327,3 @@ fun FinalScoreScreen(
     }   // end Box
 }
 
-/**
- * A single horizontal row in the final score table.
- *
- * Winner columns (listed in [winnerColumnIndices]) receive a gold/amber `secondary`
- * background so they stand out throughout the table — changed from the softer
- * `secondaryContainer` to the saturated amber token as requested in issue #4.
- * Their text is rendered bold for extra emphasis.
- *
- * Score cells (data rows, non-round-number columns) apply semantic colour coding
- * via [scoreColor]: green for positive/zero, red for negative.
- *
- * The first column (index 0) is the "Round" column and uses [FINAL_ROUND_COL_WIDTH];
- * all other columns use [FINAL_PLAYER_COL_WIDTH].
- *
- * @param cells               Text content for each cell, left-to-right.
- * @param isHeader            True for the column-header row (all cells rendered bold).
- * @param winnerColumnIndices Zero-based column indices to highlight as winner column(s).
- * @param scoreValues         Optional parallel list of raw score integers.
- *                            A null entry means "use default colour"; a non-null entry
- *                            triggers [scoreColor] for green/red coding.
- */
-@Composable
-private fun FinalScoreTableRow(
-    cells: List<String>,
-    isHeader: Boolean,
-    winnerColumnIndices: Set<Int>,
-    scoreValues: List<Int?>? = null
-) {
-    Row {
-        cells.forEachIndexed { index, text ->
-            val cellWidth = if (index == 0) FINAL_ROUND_COL_WIDTH else FINAL_PLAYER_COL_WIDTH
-            val isWinnerColumn = index in winnerColumnIndices
-
-            // Winner columns get a gold/amber background.
-            // Light mode: saturated `secondary` (rich amber) — vivid enough on parchment.
-            // Dark mode: `GoldWinnerDark` (muted dark gold) — `secondary` (GoldLight) is
-            //            too flashy on the dark felt surface, so we use a deeper tone.
-            val winnerBg = if (isSystemInDarkTheme()) GoldWinnerDark
-                           else MaterialTheme.colorScheme.secondary
-            val bgModifier = if (isWinnerColumn) Modifier.background(winnerBg) else Modifier
-
-            // Semantic text colour for score cells: green (positive) or red (negative).
-            // Header row and round-number column always use the default colour.
-            // On winner columns the text is drawn on `secondary` (amber); the score
-            // colour (primary = green, error = red) still provides enough contrast.
-            val textColor = if (!isHeader && scoreValues != null) {
-                val value = scoreValues.getOrNull(index)
-                if (value != null) scoreColor(value) else Color.Unspecified
-            } else {
-                Color.Unspecified
-            }
-
-            Box(
-                modifier = Modifier
-                    .width(cellWidth)
-                    .then(bgModifier)
-                    .padding(vertical = 8.dp, horizontal = 4.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = text,
-                    // Bold for the header row and for every cell in the winner's column.
-                    style = if (isHeader || isWinnerColumn) {
-                        MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
-                    } else {
-                        MaterialTheme.typography.bodyMedium
-                    },
-                    color = textColor,
-                    textAlign = TextAlign.Center,
-                    // Prevent long names from wrapping and making rows uneven.
-                    maxLines = 1
-                )
-            }
-        }
-    }
-}

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameModels.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameModels.kt
@@ -288,6 +288,70 @@ fun computeFinalTotals(
         roundHistory.sumOf { it.playerScores.getOrDefault(name, 0) }
     }
 
+// Holds the data for one row in the score table — used by buildScoreTableData()
+// and consumed by the ScoreTableRow composable in UiComponents.kt.
+//
+// `cells`       : formatted text for every column (round number first, then player totals).
+// `scoreValues` : raw integers for colour coding — null at index 0 (round-number column
+//                 has no semantic colour), non-null elsewhere.
+data class ScoreRowData(
+    val cells: List<String>,
+    val scoreValues: List<Int?>
+)
+
+// Builds the list of per-round data rows for the score table.
+//
+// This pure function (no Compose/UI dependencies) was extracted to eliminate the
+// identical running-totals accumulation loop that was copy-pasted between
+// ScoreHistoryScreen and FinalScoreScreen (issue #75). Keeping it here means any
+// bug fix or formatting change automatically applies to both screens, and it can
+// be unit-tested on the JVM without an emulator.
+//
+// Algorithm: iterate rounds in order, maintaining a mutable running-total map.
+// For each round:
+//   1. Add the round's per-player delta to the running totals.
+//   2. Format each total as "+N" (≥0) or "-N" (<0).
+//   3. Emit a ScoreRowData with the formatted strings and the raw integer totals.
+//
+// Skipped rounds (playerScores == emptyMap) contribute 0 to every player's total.
+fun buildScoreTableData(
+    playerNames: List<String>,
+    roundHistory: List<RoundResult>
+): List<ScoreRowData> {
+    // Start every player at 0 and accumulate as we iterate.
+    val runningTotals = playerNames.associateWith { 0 }.toMutableMap()
+
+    return roundHistory.map { round ->
+        // Add this round's contribution to each player's running total.
+        for (name in playerNames) {
+            runningTotals[name] =
+                (runningTotals[name] ?: 0) + round.playerScores.getOrDefault(name, 0)
+        }
+
+        // Formatted cell strings: round number first, then cumulative totals with sign.
+        val cells = buildList {
+            add(round.roundNumber.toString())
+            for (name in playerNames) {
+                val total = runningTotals[name] ?: 0
+                // Always show the sign so positive/negative is immediately visible.
+                val sign = if (total >= 0) "+" else ""
+                add("$sign$total")
+            }
+        }
+
+        // Parallel raw integers for colour coding.
+        // Index 0 is null — the round-number column has no semantic colour.
+        val scoreValues: List<Int?> = buildList {
+            add(null)
+            for (name in playerNames) {
+                add(runningTotals[name] ?: 0)
+            }
+        }
+
+        ScoreRowData(cells = cells, scoreValues = scoreValues)
+    }
+}
+
 // Returns the name(s) of the player(s) with the highest cumulative total.
 //
 // Returns an empty list when `totals` is empty (no players).

--- a/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
@@ -3,7 +3,6 @@ package fr.mandarine.tarotcounter
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -19,22 +17,10 @@ import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-
-// Width for the "Round" / "Manche" column — short because round numbers only go up to ~99.
-private val ROUND_COL_WIDTH: Dp = 64.dp
-
-// Width for each player column — wide enough for score strings like "+1000"
-// and player names up to about 8 characters.
-private val PLAYER_COL_WIDTH: Dp = 80.dp
 
 /**
  * ScoreHistoryScreen displays the score evolution as a table.
@@ -116,46 +102,16 @@ fun ScoreHistoryScreen(
                 )
                 HorizontalDivider()
 
-            // `runningTotals` accumulates each player's score as we iterate rounds.
-            // We start everyone at 0 and add their per-round delta on each iteration.
-            val runningTotals = playerNames.associateWith { 0 }.toMutableMap()
-
-            for (round in roundHistory) {
-                // Add this round's scores to each player's running total.
-                // `getOrDefault(name, 0)` returns 0 for skipped rounds, which have an
-                // empty `playerScores` map — so skipped rounds don't change totals.
-                for (name in playerNames) {
-                    runningTotals[name] =
-                        (runningTotals[name] ?: 0) + round.playerScores.getOrDefault(name, 0)
+                // buildScoreTableData() (GameModels.kt) accumulates the running totals and
+                // formats each cell — the loop that was previously duplicated here is now
+                // shared with FinalScoreScreen (issue #75).
+                for (row in buildScoreTableData(playerNames, roundHistory)) {
+                    ScoreTableRow(
+                        cells       = row.cells,
+                        isHeader    = false,
+                        scoreValues = row.scoreValues
+                    )
                 }
-
-                // Build the cell list: round number first, then cumulative score per player.
-                val cells = buildList {
-                    add(round.roundNumber.toString())
-                    for (name in playerNames) {
-                        val total = runningTotals[name] ?: 0
-                        // Prefix "+" for non-negative values so the sign is always visible.
-                        val sign = if (total >= 0) "+" else ""
-                        add("$sign$total")
-                    }
-                }
-
-                // Build a parallel list of integer score values for colour coding.
-                // Index 0 is null (round-number column has no semantic colour);
-                // indices 1+ hold the running total so ScoreTableRow can call scoreColor().
-                val scoreValues: List<Int?> = buildList {
-                    add(null) // round-number column — no colour
-                    for (name in playerNames) {
-                        add(runningTotals[name] ?: 0)
-                    }
-                }
-
-                ScoreTableRow(
-                    cells = cells,
-                    isHeader = false,
-                    scoreValues = scoreValues
-                )
-            }
         }
 
             // Arrow hint: floats at the top-right corner of the Box.
@@ -177,59 +133,3 @@ fun ScoreHistoryScreen(
     }   // end (centering) Box
 }
 
-/**
- * A single horizontal row in the score table.
- *
- * The first cell (index 0) uses [ROUND_COL_WIDTH]; all other cells use [PLAYER_COL_WIDTH].
- * This keeps the "Round" column compact while giving player names room to breathe.
- *
- * @param cells       Text content for each cell in left-to-right order.
- * @param isHeader    If true, renders the text in bold (used for the header row).
- * @param scoreValues Optional parallel list of raw score integers used for colour coding.
- *                    A null entry (or a null list) means "use the default text colour".
- *                    Non-null entries are passed to [scoreColor] so positive values appear
- *                    green and negative values appear red.
- */
-@Composable
-private fun ScoreTableRow(
-    cells: List<String>,
-    isHeader: Boolean,
-    scoreValues: List<Int?>? = null
-) {
-    Row {
-        cells.forEachIndexed { index, text ->
-            // First column ("Round") is narrower; player columns are wider.
-            val cellWidth = if (index == 0) ROUND_COL_WIDTH else PLAYER_COL_WIDTH
-
-            // Determine the text colour: semantic colour for score cells, default otherwise.
-            // `Color.Unspecified` tells Compose to inherit from the parent (i.e. default colour).
-            val textColor = if (!isHeader && scoreValues != null) {
-                val value = scoreValues.getOrNull(index)
-                if (value != null) scoreColor(value) else Color.Unspecified
-            } else {
-                Color.Unspecified
-            }
-
-            Box(
-                modifier = Modifier
-                    .width(cellWidth)
-                    .padding(vertical = 8.dp, horizontal = 4.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = text,
-                    style = if (isHeader) {
-                        // Bold weight for the header row so column labels stand out.
-                        MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
-                    } else {
-                        MaterialTheme.typography.bodyMedium
-                    },
-                    color = textColor,
-                    textAlign = TextAlign.Center,
-                    // Prevent very long names from wrapping and making rows uneven.
-                    maxLines = 1
-                )
-            }
-        }
-    }
-}

--- a/app/src/main/java/fr/mandarine/tarotcounter/UiComponents.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/UiComponents.kt
@@ -1,7 +1,10 @@
 package fr.mandarine.tarotcounter
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -12,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
@@ -38,10 +42,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import fr.mandarine.tarotcounter.ui.theme.GoldWinnerDark
 import kotlinx.coroutines.launch
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -436,6 +445,97 @@ fun CompactBonusGrid(
                         modifier = Modifier.weight(colWeight)
                     )
                 }
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared score-table building blocks
+//
+// These were extracted from ScoreHistoryScreen and FinalScoreScreen (issue #75)
+// to eliminate duplication: any bug fix or visual change now applies everywhere.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Width for the "Round" / "Manche" column — short, as round numbers are at most two digits.
+internal val SCORE_TABLE_ROUND_COL_WIDTH: Dp = 64.dp
+
+// Width for each player column — wide enough for score strings like "+1000"
+// and player names up to about 8 characters.
+internal val SCORE_TABLE_PLAYER_COL_WIDTH: Dp = 80.dp
+
+/**
+ * A single horizontal row in a score table.
+ *
+ * Replaces the near-identical `ScoreTableRow` (ScoreHistoryScreen) and
+ * `FinalScoreTableRow` (FinalScoreScreen) that existed before issue #75.
+ *
+ * The first column (index 0) uses [SCORE_TABLE_ROUND_COL_WIDTH]; all others use
+ * [SCORE_TABLE_PLAYER_COL_WIDTH].
+ *
+ * @param cells               Text content for each cell in left-to-right order.
+ * @param isHeader            If true, renders all text in bold (header row).
+ * @param scoreValues         Optional parallel list of raw score integers for colour
+ *                            coding. A null entry means "use the default text colour";
+ *                            a non-null entry is passed to [scoreColor].
+ * @param winnerColumnIndices Zero-based column indices to highlight with a gold background
+ *                            and bold text. Defaults to an empty set (no highlighting),
+ *                            so ScoreHistoryScreen can use this composable unchanged.
+ */
+@Composable
+fun ScoreTableRow(
+    cells: List<String>,
+    isHeader: Boolean,
+    scoreValues: List<Int?>? = null,
+    winnerColumnIndices: Set<Int> = emptySet()
+) {
+    Row {
+        cells.forEachIndexed { index, text ->
+            // First column ("Round") is narrower; all player columns are wider.
+            val cellWidth = if (index == 0) SCORE_TABLE_ROUND_COL_WIDTH
+                            else           SCORE_TABLE_PLAYER_COL_WIDTH
+
+            val isWinnerColumn = index in winnerColumnIndices
+
+            // Winner columns: saturated amber in light mode, muted dark gold in dark mode.
+            // `Color.Unspecified` leaves the background transparent (no winner highlight).
+            val bgColor = when {
+                isWinnerColumn && isSystemInDarkTheme() -> GoldWinnerDark
+                isWinnerColumn                          -> MaterialTheme.colorScheme.secondary
+                else                                    -> Color.Unspecified
+            }
+            val bgModifier = if (bgColor != Color.Unspecified) Modifier.background(bgColor)
+                             else Modifier
+
+            // Semantic colour for score cells: green (positive/zero) or red (negative).
+            // Header rows and the round-number column (null scoreValue) always use default.
+            val textColor = if (!isHeader && scoreValues != null) {
+                val value = scoreValues.getOrNull(index)
+                if (value != null) scoreColor(value) else Color.Unspecified
+            } else {
+                Color.Unspecified
+            }
+
+            Box(
+                modifier = Modifier
+                    .width(cellWidth)
+                    .then(bgModifier)
+                    .padding(vertical = 8.dp, horizontal = 4.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = text,
+                    // Bold for header rows and for every cell in a winner column.
+                    style = if (isHeader || isWinnerColumn) {
+                        MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
+                    } else {
+                        MaterialTheme.typography.bodyMedium
+                    },
+                    color = textColor,
+                    textAlign = TextAlign.Center,
+                    // Prevent long names from wrapping and making rows uneven.
+                    maxLines = 1
+                )
             }
         }
     }

--- a/app/src/test/java/fr/mandarine/tarotcounter/GameModelsTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/GameModelsTest.kt
@@ -1078,4 +1078,139 @@ class GameModelsTest {
         assertEquals(0, 91 - 91)
         assertFalse(takerWon(bouts = 3, points = 0))  // loses even with 3 bouts (needs ≥36)
     }
+
+    // ── buildScoreTableData ───────────────────────────────────────────────────
+    //
+    // Spec: the function accumulates per-round deltas into running totals, formats
+    // each total with an explicit sign (+N / -N), and returns one ScoreRowData per
+    // round with (a) the formatted cell strings and (b) raw integer values for
+    // colour coding. It was extracted from ScoreHistoryScreen / FinalScoreScreen
+    // in issue #75 to eliminate the duplicated running-totals loop.
+
+    @Test
+    fun `buildScoreTableData returns empty list when roundHistory is empty`() {
+        val result = buildScoreTableData(listOf("Alice", "Bob"), emptyList())
+        assertTrue("Expected empty list for empty history", result.isEmpty())
+    }
+
+    @Test
+    fun `buildScoreTableData returns one row per round`() {
+        val rounds = listOf(
+            RoundResult(1, "Alice", null, null, null,
+                mapOf("Alice" to 50, "Bob" to -25, "Charlie" to -25)),
+            RoundResult(2, "Bob",   null, null, null,
+                mapOf("Alice" to -30, "Bob" to 15, "Charlie" to 15))
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob", "Charlie"), rounds)
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `buildScoreTableData first cell is the round number`() {
+        val rounds = listOf(
+            RoundResult(3, "Alice", null, null, null,
+                mapOf("Alice" to 10, "Bob" to -10))
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob"), rounds)
+        assertEquals("3", result[0].cells[0])
+    }
+
+    @Test
+    fun `buildScoreTableData formats positive total with plus sign`() {
+        val rounds = listOf(
+            RoundResult(1, "Alice", null, null, null,
+                mapOf("Alice" to 50, "Bob" to -25))
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob"), rounds)
+        // cells[1] is Alice's cumulative total after round 1 → +50
+        assertEquals("+50", result[0].cells[1])
+    }
+
+    @Test
+    fun `buildScoreTableData formats negative total without plus sign`() {
+        val rounds = listOf(
+            RoundResult(1, "Alice", null, null, null,
+                mapOf("Alice" to 50, "Bob" to -25))
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob"), rounds)
+        // cells[2] is Bob's cumulative total after round 1 → -25
+        assertEquals("-25", result[0].cells[2])
+    }
+
+    @Test
+    fun `buildScoreTableData formats zero total with plus sign`() {
+        val rounds = listOf(
+            RoundResult(1, "Alice", null, null, null,
+                mapOf("Alice" to 0, "Bob" to 0))
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob"), rounds)
+        assertEquals("+0", result[0].cells[1])
+        assertEquals("+0", result[0].cells[2])
+    }
+
+    @Test
+    fun `buildScoreTableData accumulates running totals across rounds`() {
+        // Round 1: Alice +50, Bob -25  →  Alice 50, Bob -25
+        // Round 2: Alice -30, Bob +15  →  Alice 20, Bob -10
+        val rounds = listOf(
+            RoundResult(1, "Alice", null, null, null,
+                mapOf("Alice" to 50, "Bob" to -25)),
+            RoundResult(2, "Bob",   null, null, null,
+                mapOf("Alice" to -30, "Bob" to 15))
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob"), rounds)
+        // After round 1
+        assertEquals("+50", result[0].cells[1])
+        assertEquals("-25", result[0].cells[2])
+        // After round 2 — cumulative, not just the round delta
+        assertEquals("+20", result[1].cells[1])
+        assertEquals("-10", result[1].cells[2])
+    }
+
+    @Test
+    fun `buildScoreTableData scoreValues index 0 is null (round-number column)`() {
+        val rounds = listOf(
+            RoundResult(1, "Alice", null, null, null,
+                mapOf("Alice" to 50, "Bob" to -25))
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob"), rounds)
+        // Index 0 is the round-number column — no semantic colour.
+        assertNull(result[0].scoreValues[0])
+    }
+
+    @Test
+    fun `buildScoreTableData scoreValues for player columns hold raw integer totals`() {
+        val rounds = listOf(
+            RoundResult(1, "Alice", null, null, null,
+                mapOf("Alice" to 50, "Bob" to -25))
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob"), rounds)
+        assertEquals(50,  result[0].scoreValues[1])
+        assertEquals(-25, result[0].scoreValues[2])
+    }
+
+    @Test
+    fun `buildScoreTableData skipped rounds (empty playerScores) do not change totals`() {
+        // Round 1: normal round — Alice +50, Bob -25.
+        // Round 2: skipped (no playerScores) — totals unchanged.
+        val rounds = listOf(
+            RoundResult(1, "Alice", null, null, null,
+                mapOf("Alice" to 50, "Bob" to -25)),
+            RoundResult(2, "Bob",   null, null, null)  // skipped: playerScores = emptyMap()
+        )
+        val result = buildScoreTableData(listOf("Alice", "Bob"), rounds)
+        // Round 2 row: totals must still be +50 / -25 (unchanged from round 1).
+        assertEquals("+50", result[1].cells[1])
+        assertEquals("-25", result[1].cells[2])
+    }
+
+    @Test
+    fun `buildScoreTableData cells list length equals playerCount plus 1`() {
+        // 1 extra cell for the round-number column.
+        val players = listOf("Alice", "Bob", "Charlie")
+        val rounds  = listOf(RoundResult(1, "Alice", null, null, null))
+        val result  = buildScoreTableData(players, rounds)
+        assertEquals(players.size + 1, result[0].cells.size)
+        assertEquals(players.size + 1, result[0].scoreValues.size)
+    }
 }

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -142,6 +142,47 @@ SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
 
 ---
 
+## ScoreTableRow
+
+```kotlin
+@Composable
+fun ScoreTableRow(
+    cells: List<String>,
+    isHeader: Boolean,
+    scoreValues: List<Int?>? = null,
+    winnerColumnIndices: Set<Int> = emptySet()
+)
+```
+
+A single horizontal row in a score table. Used by both `ScoreHistoryScreen` and `FinalScoreScreen`.
+
+- **Column widths:** index 0 ("Round") → `SCORE_TABLE_ROUND_COL_WIDTH` (64 dp); all other columns → `SCORE_TABLE_PLAYER_COL_WIDTH` (80 dp).
+- **`isHeader`:** renders all text bold (for the header row).
+- **`scoreValues`:** parallel list of raw integers for semantic colour coding via `scoreColor()`. Pass `null` or include `null` entries to skip colouring for that cell. Index 0 should always be `null` (round-number column has no colour).
+- **`winnerColumnIndices`:** zero-based column indices highlighted with a gold/amber background and bold text. Defaults to `emptySet()` (no highlighting), so `ScoreHistoryScreen` can use this composable without any extra arguments. `FinalScoreScreen` passes the winner column indices.
+
+**Usage (ScoreHistoryScreen — no winner highlighting):**
+```kotlin
+ScoreTableRow(
+    cells    = listOf(strings.roundColumn) + playerNames,
+    isHeader = true
+)
+```
+
+**Usage (FinalScoreScreen — with winner highlighting):**
+```kotlin
+ScoreTableRow(
+    cells               = row.cells,
+    isHeader            = false,
+    scoreValues         = row.scoreValues,
+    winnerColumnIndices = winnerColumnIndices
+)
+```
+
+The data for each row is produced by `buildScoreTableData()` in `GameModels.kt`.
+
+---
+
 ## FormLabel
 
 ```kotlin


### PR DESCRIPTION
## Summary

- Extracted `buildScoreTableData(playerNames, roundHistory)` as a pure function in `GameModels.kt` — eliminates the identical running-totals accumulation loop that was copy-pasted between `ScoreHistoryScreen` and `FinalScoreScreen`
- Unified `ScoreTableRow` / `FinalScoreTableRow` into a single `ScoreTableRow` composable in `UiComponents.kt` with an optional `winnerColumnIndices: Set<Int> = emptySet()` parameter — `ScoreHistoryScreen` needs no extra args; `FinalScoreScreen` passes the winner indices for gold highlighting
- Removed the four duplicated column-width constants (`ROUND_COL_WIDTH`, `PLAYER_COL_WIDTH`, `FINAL_ROUND_COL_WIDTH`, `FINAL_PLAYER_COL_WIDTH`) — replaced by a single pair in `UiComponents.kt`

## Test plan

- [ ] 11 new unit tests for `buildScoreTableData` in `GameModelsTest` (`./gradlew testDebugUnitTest` — all pass)
- [ ] `./gradlew lint` — no new warnings
- [ ] Existing UI tests for `ScoreHistoryScreen` and `FinalScoreScreen` continue to pass on device (`./gradlew connectedAndroidTest`)
- [ ] Visually verify: score table renders identically on both screens (colour coding, winner column gold highlight)

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)