### PR TITLE
refactor(77): extract Int.withSign() to eliminate repeated score-sign pattern

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppLocale.kt
@@ -51,7 +51,8 @@ data class AppStrings(
     val resume: String,
     val noRoundsPlayed: String,
     // Single-winner summary in the past-game card, e.g. "Winner: Alice (+120)".
-    val winnerResult: (name: String, sign: String, score: Int) -> String,
+    // `formattedScore` is already sign-prefixed (e.g. "+120") via Int.withSign().
+    val winnerResult: (name: String, formattedScore: String) -> String,
     // Tie summary in the past-game card, e.g. "Tie: Alice & Bob".
     val tieResult: (names: String) -> String,
     // "1 round" vs "N rounds" shown in the past-game card footer.
@@ -122,7 +123,8 @@ data class AppStrings(
     val gameOver: String,
     val winner: String,
     // "+N pts" score label shown below the winner name.
-    val scoreDisplay: (sign: String, score: Int) -> String,
+    // `formattedScore` is already sign-prefixed (e.g. "+42") via Int.withSign().
+    val scoreDisplay: (formattedScore: String) -> String,
     val itsATie: String,
     val newGame: String,
 
@@ -165,7 +167,7 @@ val EnStrings = AppStrings(
     resumeRoundDetail     = { round, label -> "Round $round · $label" },
     resume                = "Resume",
     noRoundsPlayed        = "No rounds played",
-    winnerResult          = { name, sign, score -> "Winner: $name ($sign$score)" },
+    winnerResult          = { name, formattedScore -> "Winner: $name ($formattedScore)" },
     tieResult             = { names -> "Tie: $names" },
     roundCount            = { n -> if (n == 1) "1 round" else "$n rounds" },
 
@@ -209,7 +211,7 @@ val EnStrings = AppStrings(
     backToGame            = "Back to game",
     gameOver              = "Game Over",
     winner                = "Winner",
-    scoreDisplay          = { sign, score -> "$sign$score pts" },
+    scoreDisplay          = { formattedScore -> "$formattedScore pts" },
     itsATie               = "It's a tie!",
     newGame               = "New Game",
 
@@ -243,7 +245,7 @@ val FrStrings = AppStrings(
     resumeRoundDetail     = { round, label -> "Manche $round · $label" },
     resume                = "Reprendre",
     noRoundsPlayed        = "Aucune manche jouée",
-    winnerResult          = { name, sign, score -> "Gagnant : $name ($sign$score)" },
+    winnerResult          = { name, formattedScore -> "Gagnant : $name ($formattedScore)" },
     tieResult             = { names -> "Égalité : $names" },
     roundCount            = { n -> if (n == 1) "1 manche" else "$n manches" },
 
@@ -287,7 +289,7 @@ val FrStrings = AppStrings(
     backToGame            = "Retour à la partie",
     gameOver              = "Fin de partie",
     winner                = "Gagnant·e",
-    scoreDisplay          = { sign, score -> "$sign$score pts" },
+    scoreDisplay          = { formattedScore -> "$formattedScore pts" },
     itsATie               = "Égalité !",
     newGame               = "Nouvelle partie",
 

--- a/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
@@ -206,9 +206,8 @@ fun FinalScoreScreen(
                             )
                         }
                         val score = totals[winners.first()] ?: 0
-                        val sign = if (score >= 0) "+" else ""
                         Text(
-                            text = strings.scoreDisplay(sign, score),
+                            text = strings.scoreDisplay(score.withSign()),
                             style = MaterialTheme.typography.titleMedium,
                             color = MaterialTheme.colorScheme.onSecondaryContainer
                         )

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameModels.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameModels.kt
@@ -3,6 +3,13 @@ package fr.mandarine.tarotcounter
 import kotlin.math.abs
 import kotlinx.serialization.Serializable
 
+// Formats an integer score with an explicit sign so the direction is always visible:
+//   42  → "+42"
+//   -5  → "-5"
+//   0   → "+0"
+// Used everywhere a cumulative or final score is displayed in the UI.
+fun Int.withSign(): String = if (this >= 0) "+$this" else "$this"
+
 // The contracts a player can announce in French Tarot, ordered from weakest to strongest.
 // Each entry has a `displayName` shown in the UI and a `multiplier` used in score calculation.
 //   PRISE    × 1  (formerly called "Petite" in some regional variants)
@@ -334,8 +341,7 @@ fun buildScoreTableData(
             for (name in playerNames) {
                 val total = runningTotals[name] ?: 0
                 // Always show the sign so positive/negative is immediately visible.
-                val sign = if (total >= 0) "+" else ""
-                add("$sign$total")
+                add(total.withSign())
             }
         }
 

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -648,7 +648,6 @@ private fun CompactScoreboard(
             for (name in displayNames) {
                 // Sum every round's score for this player (0 for skipped rounds).
                 val total = roundHistory.sumOf { it.playerScores[name] ?: 0 }
-                val sign  = if (total >= 0) "+" else ""
 
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
@@ -658,7 +657,7 @@ private fun CompactScoreboard(
                         overflow = TextOverflow.Ellipsis
                     )
                     Text(
-                        text  = "$sign$total",
+                        text  = total.withSign(),
                         style = MaterialTheme.typography.titleMedium,
                         // Green for positive/zero scores, red for negative.
                         color = scoreColor(total)

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -433,9 +433,7 @@ private fun PastGameCard(game: SavedGame, strings: AppStrings) {
         winners.isEmpty() -> strings.noRoundsPlayed
         winners.size == 1 -> {
             val score = game.finalScores[winners.first()] ?: 0
-            // Prepend "+" for positive scores so the sign is always explicit.
-            val sign = if (score >= 0) "+" else ""
-            strings.winnerResult(winners.first(), sign, score)
+            strings.winnerResult(winners.first(), score.withSign())
         }
         else -> strings.tieResult(winners.joinToString(" & "))
     }

--- a/app/src/test/java/fr/mandarine/tarotcounter/AppLocaleTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/AppLocaleTest.kt
@@ -98,13 +98,14 @@ class AppLocaleTest {
 
     @Test
     fun en_winnerResult_formats_correctly() {
-        val result = appStrings(AppLocale.EN).winnerResult("Alice", "+", 150)
+        // formattedScore is pre-formatted via Int.withSign() at the call site.
+        val result = appStrings(AppLocale.EN).winnerResult("Alice", "+150")
         assertEquals("Winner: Alice (+150)", result)
     }
 
     @Test
     fun fr_winnerResult_formats_correctly() {
-        val result = appStrings(AppLocale.FR).winnerResult("Alice", "+", 150)
+        val result = appStrings(AppLocale.FR).winnerResult("Alice", "+150")
         assertEquals("Gagnant : Alice (+150)", result)
     }
 
@@ -275,16 +276,16 @@ class AppLocaleTest {
 
     @Test
     fun scoreDisplay_formats_positive_score() {
-        // The sign is passed in by the caller so the lambda only concatenates.
-        val en = appStrings(AppLocale.EN).scoreDisplay("+", 120)
-        val fr = appStrings(AppLocale.FR).scoreDisplay("+", 120)
+        // formattedScore is pre-formatted via Int.withSign() at the call site.
+        val en = appStrings(AppLocale.EN).scoreDisplay("+120")
+        val fr = appStrings(AppLocale.FR).scoreDisplay("+120")
         assertEquals("+120 pts", en)
         assertEquals("Both locales must produce the same scoreDisplay string", en, fr)
     }
 
     @Test
     fun scoreDisplay_formats_negative_score() {
-        assertEquals("-45 pts", appStrings(AppLocale.EN).scoreDisplay("-", 45))
+        assertEquals("-45 pts", appStrings(AppLocale.EN).scoreDisplay("-45"))
     }
 
     // ── chelemPlaysFirst lambda ───────────────────────────────────────────────

--- a/app/src/test/java/fr/mandarine/tarotcounter/GameModelsTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/GameModelsTest.kt
@@ -17,6 +17,23 @@ import org.junit.Test
  */
 class GameModelsTest {
 
+    // ── Int.withSign ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `withSign prefixes positive integer with plus sign`() {
+        assertEquals("+42", 42.withSign())
+    }
+
+    @Test
+    fun `withSign zero is treated as positive`() {
+        assertEquals("+0", 0.withSign())
+    }
+
+    @Test
+    fun `withSign negative integer keeps its minus sign`() {
+        assertEquals("-5", (-5).withSign())
+    }
+
     // ── Contract ──────────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

- Add `fun Int.withSign(): String` extension in `GameModels.kt` — formats integers with an explicit sign (`+42`, `-5`, `+0`)
- Replace four ad-hoc `val sign = if (...) "+" else ""` occurrences in `GameScreen`, `FinalScoreScreen`, `LandingScreen`, and `GameModels` with `x.withSign()`
- Simplify `AppStrings.scoreDisplay` and `AppStrings.winnerResult` lambda signatures to accept a single pre-formatted score string instead of a `(sign, score)` pair

## Test plan

- [ ] New unit tests for `withSign()` (positive, zero, negative) in `GameModelsTest`
- [ ] Existing `AppLocaleTest` tests updated to match the new `scoreDisplay` / `winnerResult` signatures
- [ ] `./gradlew testDebugUnitTest` — all tests pass
- [ ] `./gradlew lint` — no new warnings

Closes #77