### PR TITLE
refactor(80): merge Navigation.kt into MainActivity.kt

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
@@ -18,6 +18,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
 import java.util.Locale
 
+// Represents which screen is currently shown in the app.
+// SETUP = the player name entry screen.
+// GAME  = the active game session.
+enum class Screen { SETUP, GAME }
+
 // MainActivity is the entry point of every Android app.
 // It extends ComponentActivity, which is the base class for activities
 // that use Jetpack Compose for their UI.

--- a/app/src/main/java/fr/mandarine/tarotcounter/Navigation.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/Navigation.kt
@@ -1,6 +1,0 @@
-package fr.mandarine.tarotcounter
-
-// Represents which screen is currently shown in the app.
-// SETUP = the player name entry screen.
-// GAME  = the active game session.
-enum class Screen { SETUP, GAME }


### PR DESCRIPTION
## Summary

- Moves `enum class Screen { SETUP, GAME }` from `Navigation.kt` into `MainActivity.kt` (above the class declaration)
- Deletes `Navigation.kt` — the file contained only that enum, which is used solely by `MainActivity.kt`

No logic change. No new dependencies. All tests and lint pass.

Closes #80