### PR TITLE
fix(82): replace chelemPlayer!! force-unwrap with safe ?.let

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -527,14 +527,18 @@ fun GameScreen(
                             onSelect       = { chelemPlayer = it }
                         )
                         // Informational note: the chelem caller plays first this round.
-                        if (chelemPlayer != null &&
-                            (chelem == Chelem.ANNOUNCED_REALIZED || chelem == Chelem.ANNOUNCED_NOT_REALIZED)) {
-                            Spacer(Modifier.height(4.dp))
-                            Text(
-                                text  = strings.chelemPlaysFirst(chelemPlayer!!),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.primary
-                            )
+                        // Using ?.let instead of !! for idiomatic null-safe access:
+                        // this only renders when chelemPlayer is non-null AND the chelem
+                        // type is one that was announced (realized or not).
+                        if (chelem == Chelem.ANNOUNCED_REALIZED || chelem == Chelem.ANNOUNCED_NOT_REALIZED) {
+                            chelemPlayer?.let { player ->
+                                Spacer(Modifier.height(4.dp))
+                                Text(
+                                    text  = strings.chelemPlaysFirst(player),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Replaces the non-idiomatic `chelemPlayer!!` force-unwrap in `GameScreen.kt` with a `?.let { player -> ... }` scope function
- Reorders the condition so the `chelem` type check comes first, and null-safety on `chelemPlayer` is handled by `?.let`
- Behaviour is identical — the hint text only renders when both conditions are true

## Test plan
- [x] `./gradlew testDebugUnitTest` — passes (24 tasks, no failures)
- [x] `./gradlew lint` — no new warnings

Closes #82