### PR TITLE
fix(83): replace hardcoded height(120.dp) in ResumeGameCard accent strip with fillMaxHeight()

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
@@ -375,7 +376,7 @@ private fun ResumeGameCard(
             Box(
                 modifier = Modifier
                     .width(4.dp)
-                    .height(120.dp)           // tall enough to cover typical card content
+                    .fillMaxHeight()          // always spans the full card height, no matter how tall the content grows
                     .background(accentColor)
             )
             Column(


### PR DESCRIPTION
## Summary
- Replaces `.height(120.dp)` with `.fillMaxHeight()` on the left accent strip in `ResumeGameCard` (`LandingScreen.kt`)
- The enclosing `Row` already constrains height to the tallest child, so the strip now always spans the full card height
- Prevents a visible gap at the bottom of the strip when content wraps (long player names, long locale strings)

## Test plan
- [ ] Build and run the app; verify the accent strip fills the full card height on the Landing screen
- [ ] Test with a long player name that wraps to two lines — strip should still reach the bottom of the card
- [ ] Unit tests pass: `./gradlew testDebugUnitTest`
- [ ] Lint clean: `./gradlew lint`

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)