### PR TITLE
feat(100): set up PIT mutation testing with 80% quality gate

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -47,6 +47,12 @@ Make the changes. Follow project conventions:
 - Composable behaviour → Compose UI test in `src/androidTest/`
 - Run `./gradlew testDebugUnitTest` and fix any failures
 
+## 6b. Mutation testing
+- Run `./gradlew pitest` to validate that the new tests actually catch bugs
+- The build fails if the mutation score drops below 80 % — surviving mutants must be covered by new tests
+- Only unit-testable production classes are analysed (composables, DataStore I/O, and generated code are excluded — see `docs/mutation-testing.md`)
+- If the score is below 80 %: open `app/build/reports/pitest/index.html`, find surviving mutants, write targeted assertions, and re-run until the gate passes
+
 ## 7. Update documentation
 **This step is mandatory — never skip it.**
 - Add or update files in `docs/` describing the feature

--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ for details.
 # Instrumented tests (requires connected device or emulator)
 ./gradlew connectedAndroidTest
 
+# Mutation tests (PIT) — report: app/build/reports/pitest/index.html
+./gradlew pitest
+
 # Lint
 ./gradlew lint
 ```
@@ -196,7 +199,8 @@ TarotCounter/
 │   ├── theme.md              # Colour palette rationale and dynamic-colour policy
 │   ├── app-name.md           # App name branding and locale-specific launcher labels
 │   ├── release-signing.md    # Release signing setup for local dev and CI
-│   └── release-workflow.md   # /release-store skill: full publish workflow
+│   ├── release-workflow.md   # /release-store skill: full publish workflow
+│   └── mutation-testing.md   # PIT mutation testing: setup, quality gate, reading reports
 ├── gradle/
 │   └── libs.versions.toml  # Dependency version catalog
 ├── CLAUDE.md               # AI assistant instructions

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,153 @@ android {
     }
 }
 
+// ── Mutation testing (PIT) ────────────────────────────────────────────────────
+// PIT works by modifying ("mutating") the compiled bytecode — e.g. changing a
+// `+` to `-`, flipping a boolean — and then re-running the unit tests.
+// If a mutated build still passes all tests, the mutant "survived", which means
+// our tests are not checking that particular behaviour.
+//
+// Run:   ./gradlew pitest
+// Report: app/build/reports/pitest/index.html
+//
+// The build FAILS if the mutation score drops below 80 % (--mutationThreshold).
+// Surviving mutants must be addressed by writing new tests.
+//
+// WHY NOT the info.solidsoft.pitest Gradle plugin:
+//   The plugin's extension (PitestPluginExtension) is registered inside the
+//   plugin's own afterEvaluate hook. Under AGP 9.x, this hook never fires
+//   (the extension stays null regardless of how the plugin is applied). The
+//   root cause is an AGP / pitest-plugin afterEvaluate ordering conflict.
+//   Running PIT via JavaExec bypasses the plugin entirely and is fully
+//   compatible with any Gradle/AGP version.
+
+// A dedicated configuration to hold PIT's own JARs.
+// These are tooling, NOT app dependencies — they don't end up in the APK.
+val pitestEngine: Configuration by configurations.creating {
+    isCanBeConsumed = false  // we only resolve this, never publish it
+    isCanBeResolved = true
+    isTransitive = true      // pull in pitest's own transitive deps (pitest-core, etc.)
+}
+
+// afterEvaluate is needed so that AGP has finished registering the
+// testDebugUnitTest task (and its classpath) before we read them.
+afterEvaluate {
+
+    // The test task built by AGP for JVM unit tests (runs on the local JVM, not
+    // a device). Its .classpath includes: production classes, test classes,
+    // android.jar stubs, all runtime dependencies — everything PIT needs.
+    val testTask = tasks.named<Test>("testDebugUnitTest").get()
+
+    // Where AGP places the compiled Kotlin bytecode for the debug variant.
+    // AGP 9.x stores classes under intermediates/built_in_kotlinc/ (not tmp/kotlin-classes/).
+    val kotlinClasses = layout.buildDirectory
+        .dir("intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes")
+        .get().asFile
+
+    tasks.register<JavaExec>("pitest") {
+        group = "Verification"
+        description = "Run PIT mutation testing. Report: build/reports/pitest/index.html"
+
+        // Compile production Kotlin classes and their unit-test counterpart first.
+        dependsOn("compileDebugKotlin", "compileDebugUnitTestKotlin")
+
+        // PIT itself runs as a separate JVM process.
+        // The JVM's classpath (pitestEngine) holds PIT's own engine JARs.
+        // The application code is passed separately via --classPath below.
+        classpath = pitestEngine
+        mainClass.set("org.pitest.mutationtest.commandline.MutationCoverageReport")
+
+        val reportDir = layout.buildDirectory.dir("reports/pitest").get().asFile
+
+        // doFirst runs just before the JavaExec process is launched.
+        // We resolve the test classpath here (at execution time) to avoid
+        // forcing dependency resolution during the configuration phase.
+        doFirst {
+            reportDir.mkdirs()
+
+            // Combine the AGP-managed test classpath with the compiled Kotlin
+            // classes dir. testTask.classpath already contains almost everything;
+            // adding kotlinClasses ensures the un-transformed .class files are
+            // on the path for PIT to analyse.
+            //
+            // IMPORTANT: PIT's --classPath expects COMMA-separated entries, not
+            // the OS path separator (':' on Linux). Using asPath would produce a
+            // single colon-separated string that PIT treats as one giant path and
+            // finds no classes inside.
+            val fullClasspath = (testTask.classpath + files(kotlinClasses))
+                .files.joinToString(",") { it.absolutePath }
+
+            args(
+                // Output directory for HTML / XML reports.
+                "--reportDir", reportDir.absolutePath,
+
+                // Only mutate classes in our own package.
+                // PIT matches against the binary class name, e.g.
+                // "fr.mandarine.tarotcounter.GameModels".
+                "--targetClasses", "fr.mandarine.tarotcounter.*",
+
+                // Only use our own test classes to detect mutations.
+                "--targetTests", "fr.mandarine.tarotcounter.*",
+
+                // Source directories are used by PIT to show annotated source code
+                // in the HTML report alongside each mutation.
+                "--sourceDirs", file("src/main/kotlin").absolutePath,
+
+                // The full classpath PIT uses to load production classes (to mutate)
+                // and run the test classes (to detect mutations).
+                "--classPath", fullClasspath,
+
+                // Produce a human-readable HTML report and a CI-parseable XML report.
+                "--outputFormats", "HTML,XML",
+
+                // Parallelism: 2 threads run independent mutation analysis in parallel.
+                "--threads", "2",
+
+                // Maximum verbosity for debugging; remove once confirmed working.
+                "--verbosity", "VERBOSE",
+
+                // Quality gate: if fewer than 80 % of mutants are killed, PIT exits
+                // with a non-zero status and Gradle marks the task as FAILED.
+                // Only lower this temporarily while bootstrapping coverage; keep it
+                // at 80 for any code that merges to main.
+                "--mutationThreshold", "80",
+
+                // Exclude classes that either (a) have no unit-test coverage, (b) are
+                // generated by the Kotlin/Android toolchain, or (c) are test helpers.
+                // Categories:
+                //   - Compose UI composables: only tested via instrumented tests, not unit tests
+                //   - Generated code: serializers, R class, BuildConfig, ComposableSingletons
+                //   - Android-specific I/O: GameStorage uses DataStore which can't run on JVM
+                //   - Test files: PIT must not mutate the test code itself
+                "--excludedClasses",
+                // Auto-generated Android resources & build info
+                "fr.mandarine.tarotcounter.BuildConfig," +
+                "fr.mandarine.tarotcounter.R," +
+                // Compose screen composables (only exercised by instrumented tests)
+                "fr.mandarine.tarotcounter.GameScreenKt," +
+                "fr.mandarine.tarotcounter.LandingScreenKt," +
+                "fr.mandarine.tarotcounter.FinalScoreScreenKt," +
+                "fr.mandarine.tarotcounter.ScoreHistoryScreenKt," +
+                "fr.mandarine.tarotcounter.UiComponentsKt," +
+                "fr.mandarine.tarotcounter.ScreenHeaderKt," +
+                // Compose compiler-generated singletons
+                "fr.mandarine.tarotcounter.ComposableSingletons*," +
+                // Android Activity and DataStore storage (can't run on JVM)
+                "fr.mandarine.tarotcounter.MainActivity*," +
+                "fr.mandarine.tarotcounter.GameStorage*," +
+                // Kotlin serialization plugin-generated serializer classes
+                "fr.mandarine.tarotcounter.*\$\$serializer," +
+                "fr.mandarine.tarotcounter.*\$serializer," +
+                // Material theme declarations — pure style constants, no logic
+                "fr.mandarine.tarotcounter.ui.theme.*," +
+                // Test classes and test helpers must not be mutated
+                "fr.mandarine.tarotcounter.*Test," +
+                "fr.mandarine.tarotcounter.FakeGameStorage"
+            )
+        }
+    }
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
@@ -123,4 +270,10 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+
+    // ── PIT engine (mutation testing tooling only — not shipped in the APK) ───
+    // pitest-command-line is the entry-point JAR that drives mutation analysis.
+    // It pulls in pitest-core (the mutation engine) transitively.
+    // Version kept in sync with the version documented in docs/mutation-testing.md.
+    pitestEngine("org.pitest:pitest-command-line:1.17.3")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,8 @@ plugins {
     // `apply false` means the plugin is declared here but NOT applied to the root project.
     // It will be applied only to the :app module in its own build.gradle.kts.
     alias(libs.plugins.kotlin.serialization) apply false
+    // Note: info.solidsoft.pitest Gradle plugin is intentionally NOT used here.
+    // PIT is invoked directly as a JavaExec task in app/build.gradle.kts to avoid
+    // an AGP 9.x afterEvaluate incompatibility that prevents the plugin extension
+    // from registering. See docs/mutation-testing.md for details.
 }

--- a/docs/mutation-testing.md
+++ b/docs/mutation-testing.md
@@ -1,0 +1,84 @@
+# Mutation Testing
+
+## What is mutation testing?
+
+Mutation testing is a technique that validates how thorough our test suite really is.
+The tool (PIT) automatically modifies ("mutates") the compiled bytecode — for example, it might change a `+` to a `-`, flip a `true` to `false`, or remove a conditional — and then re-runs the unit tests against each mutated version.
+
+- **Killed mutant** — at least one test failed on the mutation → the tests caught the bug. Good.
+- **Survived mutant** — all tests still passed on the mutation → the tests missed this case. This reveals a gap.
+
+A high mutation score means the tests would catch real bugs introduced into the production code.
+
+## Tool: PIT (Pitest)
+
+We use [PIT](https://pitest.org) version **1.17.3**, invoked directly as a `JavaExec` Gradle task.
+
+> **Why not the `info.solidsoft.pitest` Gradle plugin?**
+> Under AGP 9.x, the plugin's `PitestPluginExtension` is registered inside the plugin's own
+> `afterEvaluate` hook. This hook never fires under the current AGP / Gradle version pairing,
+> leaving the extension `null` and causing the task to fail silently.
+> Calling PIT's command-line entry point via `JavaExec` bypasses the plugin entirely and works
+> with any Gradle/AGP version.
+
+## Running mutation tests
+
+```bash
+# Run PIT on the debug unit-test variant
+./gradlew pitest
+
+# The HTML report opens in a browser
+open app/build/reports/pitest/index.html
+```
+
+The task compiles the debug variant first (`compileDebugKotlin`), then runs PIT against the
+`testDebugUnitTest` classpath.
+
+## Quality gate
+
+The build **fails** if the mutation score drops below **80 %**.
+
+This threshold is intentional: it does not require 100 % (some mutants are semantically
+equivalent or untestable), but it is high enough to prevent test suites that rubber-stamp
+anything without actually asserting behaviour.
+
+If you need to temporarily lower the gate while bootstrapping coverage for a new module, lower
+`--mutationThreshold` in `app/build.gradle.kts`, add a comment explaining why, and raise it back
+once the tests are written.
+
+## What is analysed
+
+Only our own production code is mutated:
+
+- **Included**: `fr.mandarine.tarotcounter.*`
+- **Excluded** (no meaningful unit-test coverage or not runnable on JVM):
+  - Compose screen composables (`GameScreenKt`, `LandingScreenKt`, etc.) — only exercised by instrumented tests
+  - `MainActivity` — Android lifecycle, cannot run on JVM
+  - `GameStorage` — DataStore I/O, cannot run on JVM
+  - Kotlin serialization-generated classes (`*$$serializer`, `*$serializer`)
+  - Compose compiler-generated singletons (`ComposableSingletons*`)
+  - Material theme declarations (`ui.theme.*`) — pure style constants, no logic
+  - Auto-generated `R` and `BuildConfig` classes
+  - Test files themselves (`*Test`, `FakeGameStorage`)
+
+## Reading the HTML report
+
+Open `app/build/reports/pitest/index.html` after a successful run.
+
+- Green line numbers — covered and mutant was killed.
+- Red line numbers — a mutant survived here; a new assertion is needed.
+- Click a class name to see which mutations survived and on which line.
+
+## Adding mutation tests
+
+When PIT reports a surviving mutant:
+
+1. Open the HTML report and find the surviving mutant's location.
+2. Write a unit test in `src/test/` that specifically exercises that branch or arithmetic.
+3. Re-run `./gradlew pitest` and confirm the mutant is now killed.
+
+## Integration with the implement-issue workflow
+
+The `/implement-issue` skill runs `./gradlew pitest` as a validation step after the regular
+unit tests pass. If the mutation score drops below 80 %, the implementation is not complete —
+additional tests must be written to cover the gaps before the PR can be opened.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,4 +43,9 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 # Kotlin Serialization plugin: needed to generate JSON read/write code at compile time.
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+# PIT mutation testing plugin: introduces small code changes (mutants) and checks whether
+# our tests catch them. A surviving mutant means a test gap.
+# Note: the info.solidsoft.pitest Gradle plugin is NOT used here because it
+# conflicts with AGP 9.x (its afterEvaluate hook never fires under AGP).
+# PIT is invoked directly via a JavaExec task in app/build.gradle.kts instead.
 


### PR DESCRIPTION
## Summary

- Adds PIT 1.17.3 as a `JavaExec` Gradle task (`./gradlew pitest`) — avoids the `info.solidsoft.pitest` Gradle plugin which is incompatible with AGP 9.x (its `afterEvaluate` hook never fires)
- Targets all unit-testable production classes under `fr.mandarine.tarotcounter.*`; excludes composables, `MainActivity`, `GameStorage`, Kotlin/Compose-generated code, and test files
- Build fails if mutation score drops below **80 %**
- Report at `app/build/reports/pitest/index.html`

## Changes

- `app/build.gradle.kts` — `pitestEngine` configuration + `pitest` task
- `build.gradle.kts` — comment explaining why the Solidsoft plugin is not used
- `gradle/libs.versions.toml` — PIT version comment
- `docs/mutation-testing.md` — setup, quality gate, reading reports, workflow integration
- `README.md` — `./gradlew pitest` command + docs reference
- `.claude/skills/implement-issue/SKILL.md` — step 6b: run pitest after unit tests

## Test plan

- [ ] `./gradlew pitest` runs without error
- [ ] HTML report is generated at `app/build/reports/pitest/index.html`
- [ ] Mutation score is ≥ 80 % (build succeeds)
- [ ] Intentionally breaking a test causes the score to drop and the build to fail

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)