### PR TITLE
fix(106): add native debug symbols to release App Bundle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,6 +82,15 @@ android {
                 // Project-specific rules (see app/proguard-rules.pro).
                 "proguard-rules.pro"
             )
+            // Include native debug symbols in the App Bundle so Google Play Console can
+            // symbolicate native crash stack traces (e.g. from Compose's native libraries).
+            // "FULL"         → unstripped .so files (largest, most detailed — recommended for
+            //                  Play Console crash analysis)
+            // "SYMBOL_TABLE" → stripped symbols only (smaller upload, less detail)
+            // "NONE"         → default; triggers the Play Console warning we are fixing
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
         }
     }
     compileOptions {

--- a/docs/app-bundle.md
+++ b/docs/app-bundle.md
@@ -53,6 +53,38 @@ for full keystore setup and CI/CD instructions.
 If signing credentials are **not** configured, the bundle is produced unsigned and
 cannot be uploaded to the Play Store.
 
+## Native Debug Symbols
+
+Even though TarotCounter contains no custom C/C++ code, Jetpack Compose ships
+native libraries (e.g. `libandroidx.graphics.path.so`). Without debug symbols,
+Google Play Console cannot symbolicate native crash stack traces and will display
+the following warning:
+
+> *This App Bundle contains native code, and you have not imported debug symbols.*
+
+### Configuration
+
+The release build type in `app/build.gradle.kts` includes:
+
+```kotlin
+ndk {
+    debugSymbolLevel = "FULL"
+}
+```
+
+`"FULL"` instructs AGP to package the unstripped `.so` files alongside the
+stripped ones inside the App Bundle. Play Console extracts them automatically
+during the upload and uses them for crash analysis.
+
+| Value | Description |
+|---|---|
+| `"NONE"` | Default — triggers the Play Console warning |
+| `"SYMBOL_TABLE"` | Smaller upload; only symbol tables, less detail |
+| `"FULL"` | Recommended — full debug info, best crash analysis |
+
+No additional tooling or manual upload is required; the symbols are embedded in
+the `.aab` and processed by Play automatically.
+
 ## Uploading to Google Play
 
 1. Go to the [Google Play Console](https://play.google.com/console).


### PR DESCRIPTION
## Summary

- Sets `ndk { debugSymbolLevel = "FULL" }` in the release build type in `app/build.gradle.kts`
- This embeds unstripped native `.so` symbol files (from Jetpack Compose's bundled native libraries) into the App Bundle
- Resolves the Google Play Console warning: *"This App Bundle contains native code, and you have not imported debug symbols"*
- Documents the configuration in `docs/app-bundle.md` under a new "Native Debug Symbols" section

## Why FULL vs SYMBOL_TABLE

`"FULL"` provides the most detailed crash symbolication. `"SYMBOL_TABLE"` would also silence the warning but with less detail. Since the symbol files are not downloaded by users (Play extracts them server-side), the larger size has no impact on end-user download size.

## Test plan

- [ ] Build passes: `./gradlew bundleRelease`
- [ ] Lint clean: `./gradlew lint`
- [ ] Upload `.aab` to Play Console and confirm the debug symbol warning is gone

Closes #106