### PR TITLE
feat(103): add English translations for contract names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ The taker wins if they score enough points based on the number of **bouts** (spe
 
 ### Contracts (weakest → strongest)
 
-| Contract | Multiplier |
-|---|:---:|
-| Prise | ×1 |
-| Garde | ×2 |
-| Garde Sans | ×4 |
-| Garde Contre | ×6 |
+| Contract (FR) | Contract (EN) | Multiplier |
+|---|---|:---:|
+| Prise | Small | ×1 |
+| Garde | Guard | ×2 |
+| Garde Sans | Guard Without | ×4 |
+| Garde Contre | Guard Against | ×6 |
 
 ### Round Score
 

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -127,6 +127,14 @@ data class AppStrings(
     val chelemAnnouncedRealized: String,
     val chelemAnnouncedNotRealized: String,
     val chelemNotAnnouncedRealized: String,
+
+    // ── Contract enum labels ──────────────────────────────────────────────────
+    // In French (and internationally) these are always the French Tarot terms.
+    // In English, plain translations are provided for accessibility.
+    val contractPrise: String,
+    val contractGarde: String,
+    val contractGardeSans: String,
+    val contractGardeContre: String,
 )
 
 // ── English strings ───────────────────────────────────────────────────────────
@@ -203,6 +211,12 @@ val EnStrings = AppStrings(
     chelemAnnouncedRealized  = "Announced & realized",
     chelemAnnouncedNotRealized = "Announced, not realized",
     chelemNotAnnouncedRealized = "Not announced, realized",
+
+    // English translations for the four contract levels.
+    contractPrise        = "Small",
+    contractGarde        = "Guard",
+    contractGardeSans    = "Guard Without",
+    contractGardeContre  = "Guard Against",
 
     feedbackButton           = "Send Feedback",
 )
@@ -282,6 +296,12 @@ val FrStrings = AppStrings(
     chelemAnnouncedNotRealized = "Annoncé, non réalisé",
     chelemNotAnnouncedRealized = "Non annoncé, réalisé",
 
+    // French contract names — the canonical French Tarot terminology.
+    contractPrise        = "Prise",
+    contractGarde        = "Garde",
+    contractGardeSans    = "Garde Sans",
+    contractGardeContre  = "Garde Contre",
+
     feedbackButton           = "Contacter le développeur",
 )
 
@@ -294,10 +314,17 @@ fun appStrings(locale: AppLocale): AppStrings = when (locale) {
 // ── Enum localization extensions ──────────────────────────────────────────────
 
 // Returns the localized display name for a Contract.
-// The four Tarot contract names (Prise, Garde, Garde Sans, Garde Contre) are French
-// terms used internationally — they are the same in both English and French.
-@Suppress("UNUSED_PARAMETER")
-fun Contract.localizedName(locale: AppLocale): String = displayName
+// French keeps the canonical Tarot terms; English provides plain translations
+// so users unfamiliar with French Tarot can understand each contract level.
+fun Contract.localizedName(locale: AppLocale): String {
+    val strings = appStrings(locale)
+    return when (this) {
+        Contract.PRISE        -> strings.contractPrise
+        Contract.GARDE        -> strings.contractGarde
+        Contract.GARDE_SANS   -> strings.contractGardeSans
+        Contract.GARDE_CONTRE -> strings.contractGardeContre
+    }
+}
 
 // Returns the localized display name for a Chelem outcome.
 // Chelem options have meaningful translations (None/Aucun, Announced/Annoncé, etc.).

--- a/app/src/test/java/fr/mandarine/tarotcounter/AppLocaleTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/AppLocaleTest.kt
@@ -151,25 +151,55 @@ class AppLocaleTest {
     // ── Contract.localizedName ────────────────────────────────────────────────
 
     @Test
-    fun contract_names_are_same_in_both_locales() {
-        // Prise, Garde, Garde Sans, Garde Contre are French Tarot terms used internationally.
+    fun contract_localizedName_en_prise() {
+        assertEquals("Small", Contract.PRISE.localizedName(AppLocale.EN))
+    }
+
+    @Test
+    fun contract_localizedName_en_garde() {
+        assertEquals("Guard", Contract.GARDE.localizedName(AppLocale.EN))
+    }
+
+    @Test
+    fun contract_localizedName_en_garde_sans() {
+        assertEquals("Guard Without", Contract.GARDE_SANS.localizedName(AppLocale.EN))
+    }
+
+    @Test
+    fun contract_localizedName_en_garde_contre() {
+        assertEquals("Guard Against", Contract.GARDE_CONTRE.localizedName(AppLocale.EN))
+    }
+
+    @Test
+    fun contract_localizedName_fr_prise() {
+        assertEquals("Prise", Contract.PRISE.localizedName(AppLocale.FR))
+    }
+
+    @Test
+    fun contract_localizedName_fr_garde() {
+        assertEquals("Garde", Contract.GARDE.localizedName(AppLocale.FR))
+    }
+
+    @Test
+    fun contract_localizedName_fr_garde_sans() {
+        assertEquals("Garde Sans", Contract.GARDE_SANS.localizedName(AppLocale.FR))
+    }
+
+    @Test
+    fun contract_localizedName_fr_garde_contre() {
+        assertEquals("Garde Contre", Contract.GARDE_CONTRE.localizedName(AppLocale.FR))
+    }
+
+    @Test
+    fun contract_localizedName_en_and_fr_differ() {
+        // English translations must be distinct from the French Tarot terms.
         for (contract in Contract.entries) {
-            assertEquals(
-                "Contract ${contract.name} should have the same display name in EN and FR",
+            assertNotEquals(
+                "Contract ${contract.name} EN and FR names should differ",
                 contract.localizedName(AppLocale.EN),
                 contract.localizedName(AppLocale.FR)
             )
         }
-    }
-
-    @Test
-    fun contract_localizedName_returns_the_contract_displayName() {
-        // localizedName delegates to Contract.displayName — must not return an empty string
-        // or any other value. PIT would mutate the return to "" which this test catches.
-        assertEquals("Prise",         Contract.PRISE.localizedName(AppLocale.EN))
-        assertEquals("Garde",         Contract.GARDE.localizedName(AppLocale.EN))
-        assertEquals("Garde Sans",    Contract.GARDE_SANS.localizedName(AppLocale.EN))
-        assertEquals("Garde Contre",  Contract.GARDE_CONTRE.localizedName(AppLocale.EN))
     }
 
     // ── Round history string builders ─────────────────────────────────────────

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -35,12 +35,14 @@ Everything is presented on **a single scrollable page**: the compact scoreboard,
 
 The current taker's name is shown above a row of FilterChips — one per contract (weakest → strongest):
 
-| Contract     | Multiplier | Description                    |
-|--------------|:----------:|-------------------------------|
-| Prise        | ×1         | Weakest contract               |
-| Garde        | ×2         | Standard contract              |
-| Garde Sans   | ×4         | Play without the dog           |
-| Garde Contre | ×6         | Play against the dog           |
+| Contract (FR) | Contract (EN)  | Multiplier | Description                    |
+|---------------|----------------|:----------:|-------------------------------|
+| Prise         | Small          | ×1         | Weakest contract               |
+| Garde         | Guard          | ×2         | Standard contract              |
+| Garde Sans    | Guard Without  | ×4         | Play without the dog           |
+| Garde Contre  | Guard Against  | ×6         | Play against the dog           |
+
+Contract names are localized: French uses the canonical Tarot terms; English provides plain translations for accessibility.
 
 The three action buttons at the bottom of the screen let the taker confirm, skip, or end the game (see [Bottom action bar](#bottom-action-bar) below).
 


### PR DESCRIPTION
## Summary

- Adds 4 contract name fields to `AppStrings` (`contractPrise`, `contractGarde`, `contractGardeSans`, `contractGardeContre`)
- English: Small / Guard / Guard Without / Guard Against
- French: unchanged (Prise / Garde / Garde Sans / Garde Contre)
- Updates `Contract.localizedName()` to dispatch via `appStrings(locale)` instead of always returning `displayName`
- Replaces old "same in both locales" tests with locale-specific assertions (9 new test cases)

## Test plan

- [x] `./gradlew testDebugUnitTest` — all tests pass
- [x] `./gradlew pitest` — 85% mutation score (above 80% gate)
- [x] `./gradlew lint` — no new warnings

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)