### PR TITLE
fix(116): correct Poignée trump thresholds for 5-player (and 3-player) games

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Scores are zero-sum. The taker receives `±(n−1) × roundScore` for 3/4-player
 Player-assigned bonuses are entered via a compact grid with one checkbox per player. Ticking a checkbox assigns that bonus; ticking it again clears it.
 
 - **Petit au bout** — player who captured the 1 of trump on the last trick
-- **Poignée / Double poignée / Triple poignée** — trump distribution bonuses (10 / 13 / 15 trumps shown)
+- **Poignée / Double poignée / Triple poignée** — trump distribution bonuses; the minimum trump count required varies by player count (3 players: 13/15/18 · 4 players: 10/13/15 · 5 players: 8/10/13) and the tooltip in the UI always shows the correct threshold for the current game
 - **Chelem** — grand slam outcome selected from a dropdown (announced+won, announced+lost, unannounced+won, or none), with an additional player selector to record who called it. When an announced chelem is selected and a player is chosen, the app reminds the table that this player leads the first trick.
 
 ## Architecture

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -70,9 +70,12 @@ data class AppStrings(
     val triplePoignee: String,
     // Tooltip body texts shown when the user taps the ⓘ icon next to a bonus or chelem label.
     val petitTooltipBody: String,
-    val poigneeTooltipBody: String,
-    val doublePoigneeTooltipBody: String,
-    val triplePoigneeTooltipBody: String,
+    // Poignée tooltip bodies are lambdas so the trump threshold adapts to the player count.
+    // The official FFT rules specify different thresholds: 8/10/13 for 5 players,
+    // 10/13/15 for 4 players, and 13/15/18 for 3 players.
+    val poigneeTooltipBody: (playerCount: Int) -> String,
+    val doublePoigneeTooltipBody: (playerCount: Int) -> String,
+    val triplePoigneeTooltipBody: (playerCount: Int) -> String,
     val chelemTooltipBody: String,
     // Error shown below the points text field when the entered value exceeds 91.
     val pointsOutOfRange: String,
@@ -177,9 +180,10 @@ val EnStrings = AppStrings(
     doublePoignee         = "Double poignée",
     triplePoignee         = "Triple poignée",
     petitTooltipBody      = "The Petit (1 of trumps) is played in the last trick.\n+10 pts × contract multiplier.",
-    poigneeTooltipBody    = "10 trumps shown before play.\nBonus: 20 pts per player.",
-    doublePoigneeTooltipBody = "13 trumps shown before play.\nBonus: 30 pts per player.",
-    triplePoigneeTooltipBody = "15 trumps shown before play.\nBonus: 40 pts per player.",
+    // Use poigneeThresholds() to get the correct trump count for the current player count.
+    poigneeTooltipBody    = { n -> "${poigneeThresholds(n).first} trumps shown before play.\nBonus: 20 pts per player." },
+    doublePoigneeTooltipBody = { n -> "${poigneeThresholds(n).second} trumps shown before play.\nBonus: 30 pts per player." },
+    triplePoigneeTooltipBody = { n -> "${poigneeThresholds(n).third} trumps shown before play.\nBonus: 40 pts per player." },
     chelemTooltipBody     = "All tricks won by the same team.\n\nAnnounced & realized: +400 pts\nNot announced, realized: +200 pts\nAnnounced, not realized: −200 pts",
     pointsOutOfRange      = "Must be between 0 and 91",
     skipRoundConfirmTitle = "Skip this round?",
@@ -261,9 +265,10 @@ val FrStrings = AppStrings(
     doublePoignee         = "Double poignée",
     triplePoignee         = "Triple poignée",
     petitTooltipBody      = "Le Petit est joué au dernier pli.\n+10 pts × multiplicateur du contrat.",
-    poigneeTooltipBody    = "10 atouts déclarés avant le jeu.\nBonus : 20 pts par joueur.",
-    doublePoigneeTooltipBody = "13 atouts déclarés avant le jeu.\nBonus : 30 pts par joueur.",
-    triplePoigneeTooltipBody = "15 atouts déclarés avant le jeu.\nBonus : 40 pts par joueur.",
+    // Use poigneeThresholds() pour obtenir le bon seuil d'atouts selon le nombre de joueurs.
+    poigneeTooltipBody    = { n -> "${poigneeThresholds(n).first} atouts déclarés avant le jeu.\nBonus : 20 pts par joueur." },
+    doublePoigneeTooltipBody = { n -> "${poigneeThresholds(n).second} atouts déclarés avant le jeu.\nBonus : 30 pts par joueur." },
+    triplePoigneeTooltipBody = { n -> "${poigneeThresholds(n).third} atouts déclarés avant le jeu.\nBonus : 40 pts par joueur." },
     chelemTooltipBody     = "Tous les plis remportés par la même équipe.\n\nAnnoncé et réalisé : +400 pts\nNon annoncé, réalisé : +200 pts\nAnnoncé, non réalisé : −200 pts",
     pointsOutOfRange      = "Doit être entre 0 et 91",
     skipRoundConfirmTitle = "Passer ce tour ?",

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameModels.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameModels.kt
@@ -133,6 +133,24 @@ fun computePlayerScores(
     }
 }
 
+// Returns the minimum number of trumps a player must show to declare a Poignée,
+// based on the number of players in the game.
+//
+// The official FFT rules (R-RO201206.pdf) specify different thresholds per player count:
+//
+//   3 players  →  simple: 13,  double: 15,  triple: 18
+//   4 players  →  simple: 10,  double: 13,  triple: 15
+//   5 players  →  simple:  8,  double: 10,  triple: 13
+//
+// Returns a Triple of (simpleThreshold, doubleThreshold, tripleThreshold).
+// Throws IllegalArgumentException for any player count outside 3–5.
+fun poigneeThresholds(playerCount: Int): Triple<Int, Int, Int> = when (playerCount) {
+    3    -> Triple(13, 15, 18)
+    4    -> Triple(10, 13, 15)
+    5    -> Triple( 8, 10, 13)
+    else -> throw IllegalArgumentException("playerCount must be 3–5, got $playerCount")
+}
+
 // Returns the petit-au-bout bonus amount per defender.
 //
 // The petit au bout is achieved when the Petit (1 of trumps) is captured on the

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -455,9 +455,11 @@ fun GameScreen(
                     ),
                     bonusTooltips   = listOf(
                         strings.petitTooltipBody,
-                        strings.poigneeTooltipBody,
-                        strings.doublePoigneeTooltipBody,
-                        strings.triplePoigneeTooltipBody
+                        // Invoke with the actual player count so the tooltip shows the
+                        // correct trump threshold (8/10/13 for 5 players, 10/13/15 for 4, 13/15/18 for 3).
+                        strings.poigneeTooltipBody(displayNames.size),
+                        strings.doublePoigneeTooltipBody(displayNames.size),
+                        strings.triplePoigneeTooltipBody(displayNames.size)
                     ),
                     petitAuBout     = petitAuBout,    onPetit         = { petitAuBout   = it },
                     poignee         = poignee,         onPoignee       = { poignee       = it },

--- a/app/src/test/java/fr/mandarine/tarotcounter/GameModelsTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/GameModelsTest.kt
@@ -1230,4 +1230,145 @@ class GameModelsTest {
         assertEquals(players.size + 1, result[0].cells.size)
         assertEquals(players.size + 1, result[0].scoreValues.size)
     }
+
+    // ── poigneeThresholds — official FFT thresholds per player count ──────────
+    //
+    // Source: R-RO201206.pdf
+    //   Page 11 (3 players):  simple 13, double 15, triple 18
+    //   Standard (4 players): simple 10, double 13, triple 15
+    //   Page 12 (5 players):  simple  8, double 10, triple 13
+
+    @Test
+    fun `poigneeThresholds for 3 players returns 13-15-18`() {
+        // 3-player game uses more trumps per hand (24 cards each, 78-card deck).
+        // The bar for showing a Poignée is therefore higher.
+        val (simple, double, triple) = poigneeThresholds(3)
+        assertEquals(13, simple)
+        assertEquals(15, double)
+        assertEquals(18, triple)
+    }
+
+    @Test
+    fun `poigneeThresholds for 4 players returns 10-13-15`() {
+        // Standard 4-player thresholds used in most Tarot games.
+        val (simple, double, triple) = poigneeThresholds(4)
+        assertEquals(10, simple)
+        assertEquals(13, double)
+        assertEquals(15, triple)
+    }
+
+    @Test
+    fun `poigneeThresholds for 5 players returns 8-10-13`() {
+        // In 5-player games each player holds only 15 cards (distributed 3 by 3),
+        // so the Poignée bars are lower: 8, 10, and 13 trumps respectively.
+        // This matches page 12 of R-RO201206.pdf.
+        val (simple, double, triple) = poigneeThresholds(5)
+        assertEquals(8,  simple)
+        assertEquals(10, double)
+        assertEquals(13, triple)
+    }
+
+    @Test
+    fun `poigneeThresholds thresholds are strictly increasing within each player count`() {
+        // A double Poignée always requires more trumps than a simple Poignée,
+        // and a triple always requires more than a double — for every player count.
+        for (n in 3..5) {
+            val (simple, double, triple) = poigneeThresholds(n)
+            assertTrue("simple < double for $n players", simple < double)
+            assertTrue("double < triple for $n players", double < triple)
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `poigneeThresholds throws for player count below 3`() {
+        poigneeThresholds(2)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `poigneeThresholds throws for player count above 5`() {
+        poigneeThresholds(6)
+    }
+
+    // ── 5-player scoring — taker plays alone (called King in the Dog) ─────────
+    //
+    // When the called King is in the Dog, the taker plays 1 vs 4.
+    // The official rule (page 12): the taker collects ALL points in + or −.
+    // In computePlayerScores this is the case where partnerName = null in a 5-player
+    // game (allPlayers.size = 5), so numDefenders = 4 and takerMultiplier = 4.
+
+    @Test
+    fun `computePlayerScores 5-player taker-alone win — taker gets 4x, each defender gets -1x`() {
+        // 5 players, no partner (King was in the Dog): numDefenders = 4, takerMultiplier = 4.
+        // roundScore = 30 → Alice gets +120; Bob/Charlie/Dave/Eve each get -30.
+        // Sum: 120 - 30 - 30 - 30 - 30 = 0.
+        val players = listOf("Alice", "Bob", "Charlie", "Dave", "Eve")
+        val scores  = computePlayerScores(
+            allPlayers  = players,
+            takerName   = "Alice",
+            partnerName = null,   // taker plays alone — no partner
+            won         = true,
+            roundScore  = 30
+        )
+        assertEquals(+120, scores["Alice"])   // taker: +4 × 30
+        assertEquals( -30, scores["Bob"])     // defender: −30
+        assertEquals( -30, scores["Charlie"]) // defender: −30
+        assertEquals( -30, scores["Dave"])    // defender: −30
+        assertEquals( -30, scores["Eve"])     // defender: −30
+        assertEquals(0, scores.values.sum())  // zero-sum invariant
+    }
+
+    @Test
+    fun `computePlayerScores 5-player taker-alone loss — taker pays 4x, each defender gains 1x`() {
+        // Same setup, taker loses: sign flips.
+        val players = listOf("Alice", "Bob", "Charlie", "Dave", "Eve")
+        val scores  = computePlayerScores(
+            allPlayers  = players,
+            takerName   = "Alice",
+            partnerName = null,
+            won         = false,
+            roundScore  = 30
+        )
+        assertEquals(-120, scores["Alice"])   // taker: −4 × 30
+        assertEquals( +30, scores["Bob"])     // defender: +30
+        assertEquals( +30, scores["Charlie"])
+        assertEquals( +30, scores["Dave"])
+        assertEquals( +30, scores["Eve"])
+        assertEquals(0, scores.values.sum())
+    }
+
+    @Test
+    fun `computePlayerScores 5-player with partner win — taker 2x, partner 1x, defenders -1x`() {
+        // Standard 5-player game with a called partner.
+        // numDefenders = 3, takerMultiplier = 2, partnerMultiplier = 1.
+        // roundScore = 40 → Alice +80, Bob +40, Charlie/Dave/Eve -40 each.
+        val players = listOf("Alice", "Bob", "Charlie", "Dave", "Eve")
+        val scores  = computePlayerScores(
+            allPlayers  = players,
+            takerName   = "Alice",
+            partnerName = "Bob",
+            won         = true,
+            roundScore  = 40
+        )
+        assertEquals(+80, scores["Alice"])    // taker: +2 × 40
+        assertEquals(+40, scores["Bob"])      // partner: +1 × 40
+        assertEquals(-40, scores["Charlie"])  // defender: −40
+        assertEquals(-40, scores["Dave"])
+        assertEquals(-40, scores["Eve"])
+        assertEquals(0, scores.values.sum())
+    }
+
+    @Test
+    fun `computePlayerScores 5-player zero-sum holds for all roles`() {
+        // Regardless of who wins or what roundScore is, the sum of all 5 players is always 0.
+        for (won in listOf(true, false)) {
+            val scores = computePlayerScores(
+                allPlayers  = listOf("A", "B", "C", "D", "E"),
+                takerName   = "A",
+                partnerName = "B",
+                won         = won,
+                roundScore  = 57
+            )
+            assertEquals("Zero-sum must hold when won=$won", 0, scores.values.sum())
+        }
+    }
 }

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -58,10 +58,20 @@ Tapping the active chip again collapses the form and deselects the contract.
 | Points             | Number input (0–91)         | Points scored by the selected camp. When "Defenders" is chosen the app converts to taker points on confirm (`takerPoints = 91 − defenderPoints`). Values outside 0–91 show an error and disable the Confirm button. |
 | Partner            | None or any player (5-player only) | The player called by the taker as a silent partner |
 | Petit au bout      | Checkbox per player         | Player who captured the 1 of trump on the last trick |
-| Poignée            | Checkbox per player         | Player who showed a poignée (10+ trumps) |
-| Double poignée     | Checkbox per player         | Player who showed a double poignée (13+ trumps) |
-| Triple poignée     | Checkbox per player         | Player who showed a triple poignée (15+ trumps) |
+| Poignée            | Checkbox per player         | Player who showed a simple Poignée (see thresholds below) |
+| Double poignée     | Checkbox per player         | Player who showed a double Poignée (see thresholds below) |
+| Triple poignée     | Checkbox per player         | Player who showed a triple Poignée (see thresholds below) |
 | Chelem             | Self-labelled dropdown + player selector | Grand slam outcome and who called it. Shows "Chelem" when nothing is selected, otherwise the chosen outcome's name. |
+
+**Poignée trump thresholds** vary with the number of players (official FFT rules, R-RO201206.pdf):
+
+| Players | Simple Poignée | Double Poignée | Triple Poignée |
+|---------|:--------------:|:--------------:|:--------------:|
+| 3       | 13 trumps      | 15 trumps      | 18 trumps      |
+| 4       | 10 trumps      | 13 trumps      | 15 trumps      |
+| 5       |  8 trumps      | 10 trumps      | 13 trumps      |
+
+The tooltip shown next to each Poignée label in the UI automatically displays the correct threshold for the current game's player count.
 
 The four player-assigned bonuses are displayed in a compact grid. Each row shows a **label** with an ⓘ info icon immediately next to it (not pushed to the edge), and one **checkbox per player**. Tapping anywhere on the label row (the text or the icon) opens a tooltip describing the bonus and its point value — the entire row is the tap target, not only the small icon. Ticking a checkbox assigns that bonus to that player; ticking it again clears the assignment. At most one player can hold each bonus at a time.
 
@@ -154,6 +164,8 @@ The partner (5-player) does not participate in the poignée bonus exchange. The 
 
 **Example:** 4-player game, double poignée (30 pts), declared by a defender, taker loses → taker pays 30 to each of the 3 defenders (−90 for taker, +30 for each defender).
 
+The minimum number of trumps needed to declare each type differs per player count — see the [Poignée thresholds table](#poignée-trump-thresholds) in the Inline round details section above.
+
 ## Compact Scoreboard & Round History
 
 After the first round is completed the game screen shows a persistent **compact scoreboard** at the top of the page — one column per player with their name and running total. This stays visible at all times without opening a separate screen.
@@ -220,5 +232,6 @@ The bar is a direct child of the outer (non-scrollable) `Column`, which also own
 - `calculateRoundScore(contract, bouts, points)` — returns the base round score before distribution.
 - `computePlayerScores(allPlayers, takerName, partnerName, won, roundScore)` — returns a `Map<String, Int>` of player → score for the round.
 - `petitAuBoutBonus(contract)` — returns `10 × contract.multiplier`. Direction (which camp benefits) is determined in GameScreen by comparing the achiever's name against the taker/partner.
+- `poigneeThresholds(playerCount)` — returns a `Triple<Int, Int, Int>` with the minimum trump counts for (simple, double, triple) Poignée, varying by player count (3 → 13/15/18, 4 → 10/13/15, 5 → 8/10/13). Used by `AppStrings` to show the correct threshold in each tooltip.
 - `poigneeBonus(poignee, doublePoignee, triplePoignee)` — returns the flat per-defender bonus: 20, 30, 40, or 0. Direction follows the round winner, applied in GameScreen.
 - `chelemBonus(chelem)` — returns the flat per-defender bonus value: +400, +200, −200, or 0.


### PR DESCRIPTION
## Summary

- **Verified** all 5-player point calculations against the official FFT rulebook (R-RO201206.pdf, page 12): the scoring formula, win thresholds, score distribution (taker 2×/partner 1×/each defender −1×), taker-alone scenario, and all bonuses are **correct**.
- **Found bug**: Poignée tooltip texts were hardcoded to 4-player trump thresholds (10/13/15) everywhere, even in 5-player games where the official rules specify **8/10/13**, and in 3-player games where they specify **13/15/18**.
- **Fixed** by adding `poigneeThresholds(playerCount)` to `GameModels.kt` (pure, tested domain function) and making the `AppStrings` tooltip fields `(playerCount: Int) -> String` lambdas so `GameScreen` supplies the correct values at runtime.

## Changes

- `GameModels.kt`: new `poigneeThresholds(playerCount: Int): Triple<Int, Int, Int>` function with `IllegalArgumentException` guard
- `AppStrings.kt`: three tooltip fields changed from `String` to `(playerCount: Int) -> String`; `EnStrings` and `FrStrings` updated with player-count-aware lambdas
- `GameScreen.kt`: tooltip list now calls the lambdas with `displayNames.size`
- `GameModelsTest.kt`: 10 new tests — 6 for `poigneeThresholds` (3/4/5 players, monotonicity, invalid inputs) and 4 for the 5-player taker-alone scenario
- `docs/game-flow.md`, `README.md`: document the per-player-count thresholds table

## Test plan

- [x] `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL
- [x] `./gradlew pitest` — 82% mutation score (gate: 80%)
- [x] `./gradlew lint` — BUILD SUCCESSFUL, no new warnings

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)