### PR TITLE
fix(124): attribute round scores to the attacker rather than the dealer

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An Android app for tracking scores in **French Tarot**, a classic French trick-t
 TarotCounter guides players through a game round by round:
 
 1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap ☀️ or 🌙 in the top-left to toggle between light and dark mode (persisted across restarts, defaults to light); tap 🇬🇧 or 🇫🇷 in the top-right to switch the app language (persisted across restarts, defaults to device language)
-2. **Contract selection** — the current taker picks their contract; a persistent **bottom action bar** always shows **End Game** (left) and **Skip round** (right) for quick access
+2. **Attacker selection + contract** — tap the player who won the bidding to set them as the **attacker** (any player can bid, not just the dealer); then pick their contract; the dealer label shows who is distributing the cards this round; a persistent **bottom action bar** always shows **End Game** (left) and **Skip round** (right) for quick access
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
 4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first; each history row shows a colored **●** indicator (green = won, red = lost, grey = skipped) for at-a-glance scanning
 5. **Score history table** — tap the bar-chart icon (left of the header) to see a round-by-round table of cumulative scores for every player
@@ -18,7 +18,7 @@ TarotCounter guides players through a game round by round:
 10. **Back navigation** — the Android system back button always returns to the landing page; on the Final Score screen a confirmation dialog is shown first to avoid accidentally losing unsaved results
 11. **Feedback button** — a "Send Feedback" / "Contacter le développeur" button at the bottom of the setup screen opens the device's email client pre-addressed to the developer
 
-The app automatically rotates the taker each round, determines win/loss, and computes each player's score for the round.
+The app rotates the **dealer** each round and lets the user explicitly select the **attacker** (the player who won the bidding), determines win/loss, and computes each player's score for the round.
 
 ## Game Rules Summary
 

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -65,11 +65,33 @@ class GameScreenTest {
     }
 
     /**
-     * Selects [contract] then types [score] into the points field so the Confirm
-     * button becomes enabled. Required in every test that submits a round, because
-     * Confirm is now disabled until both a contract and a non-empty score are set.
+     * Selects [attackerName] as the attacker by tapping their name in the attacker
+     * segmented-button row. Must be called before selecting a contract, because the
+     * "choose a contract" prompt is only shown once an attacker is selected.
      */
-    private fun selectContractAndEnterScore(contract: String = "Garde", score: String = "45") {
+    private fun selectAttacker(attackerName: String = "Alice") {
+        // The attacker selector shows all player names as segmented-button labels.
+        // We need to find the one in the attacker row (not the bonus grid or history).
+        // Using onAllNodesWithText and picking the first match is safe because the
+        // attacker selector is the topmost occurrence of each name before the form opens.
+        composeTestRule.onAllNodesWithText(attackerName).fetchSemanticsNodes().let {
+            require(it.isNotEmpty()) { "No node found with text '$attackerName'" }
+        }
+        composeTestRule.onAllNodesWithText(attackerName)[0].performClick()
+    }
+
+    /**
+     * Selects an attacker, selects [contract], then types [score] into the points
+     * field so the Confirm button becomes enabled. Required in every test that submits
+     * a round, because Confirm is disabled until an attacker, a contract, and a
+     * non-empty score are all provided (issue #124).
+     */
+    private fun selectContractAndEnterScore(
+        attacker: String = "Alice",
+        contract: String = "Garde",
+        score: String = "45"
+    ) {
+        selectAttacker(attacker)
         composeTestRule.onNodeWithText(contract).performClick()
         composeTestRule.onNodeWithTag("points_input").performTextInput(score)
     }
@@ -147,7 +169,26 @@ class GameScreenTest {
     }
 
     @Test
-    fun confirm_button_becomes_enabled_when_contract_selected_and_score_entered() {
+    fun confirm_button_remains_disabled_when_attacker_and_contract_selected_but_no_score() {
+        // All three conditions must be met: attacker + contract + score.
+        launchGame()
+        selectAttacker()
+        composeTestRule.onNodeWithText("Garde").performClick()
+        composeTestRule.onNodeWithText("Confirm round").assertIsNotEnabled()
+    }
+
+    @Test
+    fun confirm_button_remains_disabled_when_only_attacker_selected() {
+        // Selecting only the attacker is not enough — a contract is also required.
+        launchGame()
+        selectAttacker()
+        composeTestRule.onNodeWithText("Confirm round").assertIsNotEnabled()
+    }
+
+    @Test
+    fun confirm_button_becomes_enabled_when_attacker_contract_and_score_all_set() {
+        // Fix for issue #124: attacker selection is now required in addition to
+        // contract and score before the Confirm button becomes active.
         launchGame()
         selectContractAndEnterScore()
         composeTestRule.onNodeWithText("Confirm round").assertIsEnabled()
@@ -468,6 +509,7 @@ class GameScreenTest {
     @Test
     fun entering_91_does_not_show_error() {
         launchGame()
+        selectAttacker()
         composeTestRule.onNodeWithText("Garde").performClick()
 
         composeTestRule.onNodeWithTag("points_input").performTextInput("91")
@@ -479,7 +521,9 @@ class GameScreenTest {
 
     @Test
     fun entering_91_keeps_confirm_button_enabled() {
+        // An attacker must also be selected — issue #124.
         launchGame()
+        selectAttacker()
         composeTestRule.onNodeWithText("Garde").performClick()
 
         composeTestRule.onNodeWithTag("points_input").performTextInput("91")
@@ -507,6 +551,8 @@ class GameScreenTest {
     @Test
     fun won_round_shows_won_indicator() {
         launchGame()
+        // Select an attacker (required since issue #124) before picking the contract.
+        selectAttacker()
         composeTestRule.onNodeWithText("Garde").performClick()
 
         composeTestRule.onNodeWithTag("bouts_dropdown").performClick()
@@ -677,12 +723,91 @@ class GameScreenTest {
 
         // Confirm one round so roundHistory is non-empty.
         selectContractAndEnterScore()
-        composeTestRule.onNodeWithText("Confirm").performClick()
+        composeTestRule.onNodeWithText("Confirm round").performClick()
 
         // Now end the game.
         composeTestRule.onNodeWithText("End Game").performClick()
 
         // Final Score screen must be shown.
         composeTestRule.onNodeWithText("Game Over").assertIsDisplayed()
+    }
+
+    // ── Spec: attacker selection (issue #124) ─────────────────────────────────
+    // The attacker is the player who wins the bidding and takes the contract.
+    // Any player can be the attacker, regardless of who is dealing this round.
+
+    @Test
+    fun attacker_selector_shows_all_player_names() {
+        // All players must be visible in the attacker selector so any can be chosen.
+        launchGame()
+        players.forEach { name ->
+            assertTrue(
+                "$name should appear in the attacker selector",
+                composeTestRule.onAllNodesWithText(name).fetchSemanticsNodes().isNotEmpty()
+            )
+        }
+    }
+
+    @Test
+    fun dealer_label_is_displayed() {
+        // The dealer label ("Dealer: Alice" / "Distributeur : Alice") should always
+        // be visible so the table knows whose turn it is to distribute the cards.
+        launchGame()
+        assertTrue(
+            "Dealer label should be visible",
+            composeTestRule.onAllNodesWithText("Dealer:", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        )
+    }
+
+    @Test
+    fun attacker_label_is_displayed() {
+        // The "Attacker" label should always be visible above the selector row.
+        launchGame()
+        composeTestRule.onNodeWithText("Attacker").assertIsDisplayed()
+    }
+
+    @Test
+    fun confirm_disabled_without_attacker_even_when_contract_and_score_set() {
+        // Core regression test for issue #124: scoring must go to the selected attacker.
+        // Confirm must stay disabled when no attacker is selected.
+        launchGame()
+        // Select contract and enter score, but do NOT select an attacker.
+        composeTestRule.onNodeWithText("Garde").performClick()
+        composeTestRule.onNodeWithTag("points_input").performTextInput("45")
+        composeTestRule.onNodeWithText("Confirm round").assertIsNotEnabled()
+    }
+
+    @Test
+    fun selecting_attacker_then_contract_and_score_enables_confirm() {
+        // Selecting the attacker should allow the round to be confirmed once the
+        // other required fields (contract, score) are also filled in.
+        launchGame()
+        selectContractAndEnterScore(attacker = "Bob")
+        composeTestRule.onNodeWithText("Confirm round").assertIsEnabled()
+    }
+
+    @Test
+    fun choose_contract_prompt_appears_after_attacker_is_selected() {
+        // The "Attacker — choose a contract:" prompt should appear once an attacker
+        // is selected, and include the selected attacker's name.
+        launchGame()
+        selectAttacker("Charlie")
+        composeTestRule
+            .onNodeWithText("Charlie", substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun attacker_resets_after_round_is_confirmed() {
+        // After a round is confirmed the attacker selection must clear so the next
+        // round starts fresh — no player should be pre-selected.
+        launchGame()
+        selectContractAndEnterScore(attacker = "Alice")
+        composeTestRule.onNodeWithText("Confirm round").performClick()
+
+        // After advancing to round 2, the Confirm button must again be disabled
+        // (no attacker selected yet for the new round).
+        composeTestRule.onNodeWithText("Confirm round").assertIsNotEnabled()
     }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -38,7 +38,12 @@ data class AppStrings(
     // ── Game Screen ───────────────────────────────────────────────────────────
     // "Round 1" / "Manche 1" header.
     val roundHeader: (n: Int) -> String,
-    // "{Player} — choose a contract:" prompt above the contract chips.
+    // "Dealer: Alice" label shown above the attacker selector for context.
+    val dealerLabel: (dealer: String) -> String,
+    // Label for the attacker-selector row, e.g. "Attacker" / "Preneur".
+    val attackerLabel: String,
+    // "{Attacker} — choose a contract:" prompt above the contract chips.
+    // Only shown once an attacker has been selected.
     val chooseContract: (taker: String) -> String,
     val skipRound: String,
     val numberOfBouts: String,
@@ -163,6 +168,8 @@ val EnStrings = AppStrings(
     roundCount            = { n -> if (n == 1) "1 round" else "$n rounds" },
 
     roundHeader           = { n -> "Round $n" },
+    dealerLabel           = { dealer -> "Dealer: $dealer" },
+    attackerLabel         = "Attacker",
     chooseContract        = { taker -> "$taker — choose a contract:" },
     skipRound             = "Skip round",
     numberOfBouts         = "Number of bouts (oudlers)",
@@ -249,6 +256,8 @@ val FrStrings = AppStrings(
     roundCount            = { n -> if (n == 1) "1 manche" else "$n manches" },
 
     roundHeader           = { n -> "Manche $n" },
+    dealerLabel           = { dealer -> "Distributeur : $dealer" },
+    attackerLabel         = "Preneur",
     chooseContract        = { taker -> "$taker — choisissez un contrat :" },
     skipRound             = "Passer la manche",
     numberOfBouts         = "Nombre de bouts (oudlers)",

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -80,10 +80,17 @@ fun GameScreen(
     // Read game session state from the ViewModel.
     // These are Compose snapshot values — recomposition is triggered automatically
     // when the ViewModel mutates them (e.g. after recordPlayed() advances currentRound).
-    val currentRound  = viewModel.currentRound
-    val roundHistory  = viewModel.roundHistory
-    val displayNames  = viewModel.displayNames
-    val currentTaker  = viewModel.currentTaker
+    val currentRound   = viewModel.currentRound
+    val roundHistory   = viewModel.roundHistory
+    val displayNames   = viewModel.displayNames
+    // The dealer rotates each round — they deal the cards but are not necessarily the attacker.
+    val currentDealer  = viewModel.currentDealer
+
+    // The player who won the bidding and took the contract (the attacker).
+    // null = no attacker selected yet.
+    // Any player can be the attacker, regardless of who is dealing this round.
+    // This resets to null at the start of each new round (see LaunchedEffect below).
+    var selectedAttacker by remember { mutableStateOf<String?>(null) }
 
     // The contract selected by tapping one of the contract chips.
     // null = no contract selected yet (details form is hidden).
@@ -114,6 +121,14 @@ fun GameScreen(
     var chelem           by remember { mutableStateOf(Chelem.NONE) }
     // The player who called/achieved the chelem; reset to null when chelem reverts to NONE.
     var chelemPlayer     by remember { mutableStateOf<String?>(null) }
+
+    // Reset the attacker selection each time the round counter advances.
+    // LaunchedEffect re-runs whenever its key (currentRound) changes value.
+    // Note: this runs AFTER the composition is committed, but because the assignment
+    // is non-suspending the UI reflects the reset on the very next recomposition.
+    LaunchedEffect(currentRound) {
+        selectedAttacker = null
+    }
 
     // Reset every form field whenever the selected contract changes (including to null).
     // LaunchedEffect re-runs on each new key value — the assignments are non-suspending
@@ -252,16 +267,70 @@ fun GameScreen(
             HorizontalDivider()
             Spacer(Modifier.height(12.dp))
 
-            // ── Contract selection ────────────────────────────────────────────
-            // SingleChoiceSegmentedButtonRow is the Material 3 standard for picking
-            // one option from a fixed set. Tapping the already-selected segment
-            // deselects it (collapses the details form).
+            // ── Dealer info (context) ────────────────────────────────────────
+            // Shows who is dealing this round. The dealer distributes the cards
+            // but does not automatically become the attacker.
             Text(
-                text = strings.chooseContract(currentTaker),
+                text  = strings.dealerLabel(currentDealer),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.align(Alignment.Start)
+            )
+            Spacer(Modifier.height(8.dp))
+
+            // ── Attacker selector ────────────────────────────────────────────
+            // The attacker is the player who wins the bidding — any player can bid,
+            // regardless of who is dealing. The user taps a player's name to select
+            // them as the attacker for this round. Tapping again deselects.
+            Text(
+                text  = strings.attackerLabel,
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.align(Alignment.Start)
             )
             Spacer(Modifier.height(8.dp))
+
+            // Shared font size so all player-name segments shrink together.
+            // Keyed on locale so labels re-measure when the language changes.
+            val attackerLabelSize = rememberSharedAutoSizeState(locale)
+
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                displayNames.forEachIndexed { index, name ->
+                    SegmentedButton(
+                        shape    = SegmentedButtonDefaults.itemShape(index, displayNames.size),
+                        selected = selectedAttacker == name,
+                        onClick  = {
+                            // Tapping the already-selected attacker deselects them.
+                            selectedAttacker = if (selectedAttacker == name) null else name
+                            // Deselect the contract too — changing the attacker invalidates
+                            // the current contract choice (a different player may pick differently).
+                            selectedContract = null
+                        },
+                        icon     = {}
+                    ) {
+                        AutoSizeText(
+                            text            = name,
+                            modifier        = Modifier.padding(horizontal = 1.dp),
+                            sharedSizeState = attackerLabelSize
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(8.dp))
+
+            // ── Contract selection ────────────────────────────────────────────
+            // Only shown once an attacker has been selected — the attacker's name
+            // appears in the label so the user can confirm who is playing.
+            // SingleChoiceSegmentedButtonRow is the Material 3 standard for picking
+            // one option from a fixed set. Tapping the already-selected segment
+            // deselects it (collapses the details form).
+            if (selectedAttacker != null) {
+            Text(
+                text = strings.chooseContract(selectedAttacker!!),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.align(Alignment.Start)
+            )
+            Spacer(Modifier.height(8.dp))
+            } // end attacker-required guard
 
             // Shared font size — all 4 segments shrink together so they always display
             // at the same size (the smallest needed across the longest label).
@@ -429,9 +498,12 @@ fun GameScreen(
                 Spacer(Modifier.height(12.dp))
 
                 // ── Partner selection (5-player only) ─────────────────────────
-                // In a 5-player game the taker calls a silent partner before the round.
+                // In a 5-player game the attacker calls a silent partner before the round.
                 if (displayNames.size == 5) {
-                    val partnerOptions = displayNames.filter { it != currentTaker }
+                    // The attacker cannot be their own partner, so exclude them.
+                    // Fall back to an empty list if no attacker is selected yet
+                    // (the partner selector is only reachable once an attacker is chosen).
+                    val partnerOptions = displayNames.filter { it != selectedAttacker }
                     PlayerChipSelector(
                         label          = strings.partnerCalledByTaker,
                         noneLabel      = strings.noneOption,
@@ -534,7 +606,8 @@ fun GameScreen(
                 if (chelem != Chelem.NONE) {
                     Spacer(Modifier.height(8.dp))
                     val chelemCandidates = buildList {
-                        add(currentTaker)
+                        // The selected attacker can always call chelem.
+                        selectedAttacker?.let { add(it) }
                         // In a 5-player game the partner can also call chelem.
                         if (displayNames.size == 5) selectedPartner?.let { add(it) }
                     }
@@ -630,21 +703,23 @@ fun GameScreen(
                 modifier = Modifier.weight(1f)
             )
             // Confirm: primary filled button — the main action.
-            // Disabled until a contract is selected, a score has been entered,
-            // and the points value is valid (≤ 91).
+            // Disabled until an attacker is selected, a contract is selected,
+            // a score has been entered, and the points value is valid (≤ 91).
             AppButton(
                 text     = strings.confirmRound,
-                enabled  = selectedContract != null && pointsText.isNotBlank() && !pointsError,
+                enabled  = selectedAttacker != null && selectedContract != null && pointsText.isNotBlank() && !pointsError,
                 modifier = Modifier.weight(1f),
                 onClick  = {
-                    // Guard: selectedContract is already checked by `enabled`, but Kotlin
-                    // requires a smart-cast-safe reference for use inside the lambda.
+                    // Guards: both are checked by `enabled`, but Kotlin requires
+                    // smart-cast-safe references for use inside the lambda.
+                    val attacker = selectedAttacker ?: return@AppButton
                     val contract = selectedContract ?: return@AppButton
                     // Parse the typed points; default to 0 if empty, clamp to 0–91.
                     val enteredPoints = pointsText.toIntOrNull()?.coerceIn(0, 91) ?: 0
                     // When the user entered defenders' points, convert to taker's points.
                     val points = if (defenderMode) 91 - enteredPoints else enteredPoints
                     viewModel.recordPlayed(
+                        attacker,
                         contract,
                         RoundDetails(
                             bouts         = bouts,

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameViewModel.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameViewModel.kt
@@ -113,10 +113,12 @@ class GameViewModel internal constructor(
     val startingIndex: Int get() = _startingIndex
     val gameId: String get() = _gameId
 
-    // The display name of the player who takes in the current round.
+    // The display name of the player whose turn it is to *deal* the cards this round.
+    // Deals rotate through players in setup order starting from a random first dealer.
+    // This is NOT the attacker — any player can bid and become the attacker.
     // Derived from _startingIndex and currentRound so it updates automatically
     // when currentRound (a snapshot state) changes during composition.
-    val currentTaker: String
+    val currentDealer: String
         get() {
             if (_displayNames.isEmpty()) return ""
             val index = (_startingIndex + currentRound - 1) % _displayNames.size
@@ -144,21 +146,24 @@ class GameViewModel internal constructor(
     // All scoring logic runs here — previously these calculations lived inside the
     // GameScreen composable as a local `fun recordPlayed()`, which meant they were
     // recreated on every recomposition and could not be unit-tested.
-    fun recordPlayed(contract: Contract, details: RoundDetails) {
-        val taker    = currentTaker
+    //
+    // takerName : the player who won the bidding and took the contract (the attacker).
+    //             This is explicitly passed by the UI — it is NOT derived from the
+    //             dealer rotation, because any player can bid regardless of who deals.
+    fun recordPlayed(takerName: String, contract: Contract, details: RoundDetails) {
         val won      = takerWon(details.bouts, details.points)
         val score    = calculateRoundScore(contract, details.bouts, details.points)
         val base     = computePlayerScores(
             allPlayers  = _displayNames,
-            takerName   = taker,
+            takerName   = takerName,
             partnerName = details.partnerName,
             won         = won,
             roundScore  = score
         )
         // 3/4-player: every non-taker is a defender; 5-player: exactly 3 defenders.
         val numDef   = if (details.partnerName != null) 3 else _displayNames.size - 1
-        val scores   = applyBonuses(base, contract, details, taker, won, numDef)
-        roundHistory.add(RoundResult(currentRound, taker, contract, details, won, scores))
+        val scores   = applyBonuses(base, contract, details, takerName, won, numDef)
+        roundHistory.add(RoundResult(currentRound, takerName, contract, details, won, scores))
         currentRound++
         saveInProgressGame(buildProgressSnapshot())
     }
@@ -169,7 +174,8 @@ class GameViewModel internal constructor(
         roundHistory.add(
             RoundResult(
                 roundNumber = currentRound,
-                takerName   = currentTaker,
+                // For skipped rounds, record the dealer's name as the taker (no attacker was chosen).
+                takerName   = currentDealer,
                 contract    = null,
                 details     = null,
                 won         = null

--- a/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
@@ -482,7 +482,7 @@ class GameViewModelTest {
         val vm = GameViewModel(Application(), FakeGameStorage())
         vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
 
-        vm.recordPlayed(Contract.GARDE, basicDetails())
+        vm.recordPlayed("Alice", Contract.GARDE, basicDetails())
 
         assertEquals(2, vm.currentRound)
     }
@@ -492,7 +492,7 @@ class GameViewModelTest {
         val vm = GameViewModel(Application(), FakeGameStorage())
         vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
 
-        vm.recordPlayed(Contract.GARDE, basicDetails())
+        vm.recordPlayed("Alice", Contract.GARDE, basicDetails())
 
         assertEquals(Contract.GARDE, vm.roundHistory[0].contract)
     }
@@ -503,7 +503,7 @@ class GameViewModelTest {
         val vm = GameViewModel(Application(), FakeGameStorage())
         vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
 
-        vm.recordPlayed(Contract.GARDE, basicDetails(bouts = 0, points = 0))
+        vm.recordPlayed("Alice", Contract.GARDE, basicDetails(bouts = 0, points = 0))
 
         assertEquals(false, vm.roundHistory[0].won)
     }
@@ -514,7 +514,7 @@ class GameViewModelTest {
         val vm = GameViewModel(Application(), FakeGameStorage())
         vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
 
-        vm.recordPlayed(Contract.GARDE, basicDetails(bouts = 3, points = 91))
+        vm.recordPlayed("Alice", Contract.GARDE, basicDetails(bouts = 3, points = 91))
 
         assertEquals(true, vm.roundHistory[0].won)
     }
@@ -525,7 +525,7 @@ class GameViewModelTest {
         val vm = GameViewModel(Application(), storage)
         vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
 
-        vm.recordPlayed(Contract.GARDE, basicDetails())
+        vm.recordPlayed("Alice", Contract.GARDE, basicDetails())
 
         assertEquals(1, storage.saveInProgressCallCount)
     }
@@ -536,7 +536,7 @@ class GameViewModelTest {
         val vm = GameViewModel(Application(), FakeGameStorage())
         vm.initGame(players, inProgressGame = null)
 
-        vm.recordPlayed(Contract.GARDE, basicDetails(bouts = 0, points = 0))
+        vm.recordPlayed("Alice", Contract.GARDE, basicDetails(bouts = 0, points = 0))
 
         // Every player should have a score entry (zero-sum game, so all 3 must be present).
         val scores = vm.roundHistory[0].playerScores
@@ -664,20 +664,22 @@ class GameViewModelTest {
         )
     }
 
-    // ── currentTaker ──────────────────────────────────────────────────────────
+    // ── currentDealer ─────────────────────────────────────────────────────────
+    // The dealer rotates each round. They distribute the cards but any player
+    // can bid and become the attacker.
 
     @Test
-    fun `currentTaker returns empty string when displayNames is empty`() {
+    fun `currentDealer returns empty string when displayNames is empty`() {
         val vm = GameViewModel(Application(), FakeGameStorage())
         // initGame has not been called — _displayNames is empty.
-        assertEquals("", vm.currentTaker)
+        assertEquals("", vm.currentDealer)
     }
 
     @Test
-    fun `currentTaker returns player at startingIndex for round 1`() {
+    fun `currentDealer returns player at startingIndex for round 1`() {
         val players = listOf("Alice", "Bob", "Charlie")
         val vm = GameViewModel(Application(), FakeGameStorage())
-        // Restore a game where Bob (index 1) is the first taker.
+        // Restore a game where Bob (index 1) is the first dealer.
         vm.initGame(players, InProgressGame(
             gameId        = "g1",
             playerNames   = players,
@@ -685,14 +687,14 @@ class GameViewModelTest {
             startingIndex = 1,
             rounds        = emptyList()
         ))
-        assertEquals("Bob", vm.currentTaker)
+        assertEquals("Bob", vm.currentDealer)
     }
 
     @Test
-    fun `currentTaker advances to the next player on round 2`() {
+    fun `currentDealer advances to the next player on round 2`() {
         val players = listOf("Alice", "Bob", "Charlie")
         val vm = GameViewModel(Application(), FakeGameStorage())
-        // Alice started (index 0); now it is round 2 → Bob (index 1).
+        // Alice started (index 0); now it is round 2 → Bob (index 1) deals.
         vm.initGame(players, InProgressGame(
             gameId        = "g1",
             playerNames   = players,
@@ -700,11 +702,11 @@ class GameViewModelTest {
             startingIndex = 0,
             rounds        = emptyList()
         ))
-        assertEquals("Bob", vm.currentTaker)
+        assertEquals("Bob", vm.currentDealer)
     }
 
     @Test
-    fun `currentTaker wraps back to the first player after a full cycle`() {
+    fun `currentDealer wraps back to the first player after a full cycle`() {
         val players = listOf("Alice", "Bob", "Charlie")
         val vm = GameViewModel(Application(), FakeGameStorage())
         // startingIndex=0, 3 players → round 4 wraps to index 0 (Alice again).
@@ -716,7 +718,7 @@ class GameViewModelTest {
             startingIndex = 0,
             rounds        = emptyList()
         ))
-        assertEquals("Alice", vm.currentTaker)
+        assertEquals("Alice", vm.currentDealer)
     }
 
     // ── initGame — startingIndex, gameId, displayNames ───────────────────────
@@ -776,10 +778,12 @@ class GameViewModelTest {
     // ── recordPlayed — takerName stored in history ────────────────────────────
 
     @Test
-    fun `recordPlayed stores the currentTaker as takerName in the round result`() = runTest {
+    fun `recordPlayed stores the explicitly provided takerName in the round result`() = runTest {
+        // Bug fix (issue #124): points must go to the attacker (whoever won the bid),
+        // NOT to the dealer. The takerName is now an explicit parameter.
         val players = listOf("Alice", "Bob", "Charlie")
         val vm = GameViewModel(Application(), FakeGameStorage())
-        // Charlie (index 2) is the taker for round 1.
+        // Charlie is the dealer (index 2), but Bob won the bidding.
         vm.initGame(players, InProgressGame(
             gameId        = "g1",
             playerNames   = players,
@@ -788,9 +792,30 @@ class GameViewModelTest {
             rounds        = emptyList()
         ))
 
-        vm.recordPlayed(Contract.GARDE, basicDetails())
+        // Bob won the auction — pass Bob as the attacker explicitly.
+        vm.recordPlayed("Bob", Contract.GARDE, basicDetails())
 
-        assertEquals("Charlie", vm.roundHistory[0].takerName)
+        assertEquals("Bob", vm.roundHistory[0].takerName)
+    }
+
+    @Test
+    fun `recordPlayed attacker can differ from the current dealer`() = runTest {
+        // Core regression test for issue #124: the attacker is independent of the dealer.
+        val players = listOf("Alice", "Bob", "Charlie")
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        // Alice is the first dealer (index 0, round 1).
+        vm.initGame(players, inProgressGame = null)
+        // The dealer is Alice, but Charlie won the bidding.
+        vm.recordPlayed("Charlie", Contract.PRISE, basicDetails(bouts = 0, points = 0))
+
+        val result = vm.roundHistory[0]
+        // takerName must be Charlie (the attacker), not Alice (the dealer).
+        assertEquals("Charlie", result.takerName)
+        // Charlie (the loser with 0 pts, 0 bouts) must pay — not Alice.
+        assertTrue(
+            "Attacker Charlie must have a negative score when they lost",
+            (result.playerScores["Charlie"] ?: 0) < 0
+        )
     }
 
     // ── recordPlayed — 5-player game (numDefenders = 3) ──────────────────────
@@ -821,7 +846,7 @@ class GameViewModelTest {
             doublePoignee = null,
             chelem        = Chelem.NONE
         )
-        vm.recordPlayed(Contract.GARDE, details)
+        vm.recordPlayed("Alice", Contract.GARDE, details)
 
         val scores = vm.roundHistory[0].playerScores
         assertEquals(+136, scores["Alice"])
@@ -856,7 +881,7 @@ class GameViewModelTest {
             gameId = "g1", playerNames = players,
             currentRound = 1, startingIndex = 0, rounds = emptyList()
         ))
-        vm.recordPlayed(Contract.GARDE, RoundDetails(
+        vm.recordPlayed("Alice", Contract.GARDE, RoundDetails(
             bouts         = 2,
             points        = 50,
             partnerName   = null,
@@ -904,7 +929,7 @@ class GameViewModelTest {
         val vm = GameViewModel(Application(), storage)
         vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
 
-        vm.recordPlayed(Contract.PRISE, basicDetails())
+        vm.recordPlayed("Alice", Contract.PRISE, basicDetails())
 
         assertEquals(1, storage.lastSavedInProgress?.rounds?.size)
     }
@@ -915,7 +940,7 @@ class GameViewModelTest {
         val vm = GameViewModel(Application(), storage)
         vm.initGame(listOf("Alice", "Bob", "Charlie"), inProgressGame = null)
 
-        vm.recordPlayed(Contract.PRISE, basicDetails())
+        vm.recordPlayed("Alice", Contract.PRISE, basicDetails())
 
         assertEquals(2, storage.lastSavedInProgress?.currentRound)
     }

--- a/app/src/test/java/fr/mandarine/tarotcounter/TakerRotationTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/TakerRotationTest.kt
@@ -5,15 +5,19 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Unit tests for the taker-rotation logic defined in GameScreen.kt.
+ * Unit tests for the dealer-rotation logic in GameViewModel.
  *
  * Spec (docs/game-flow.md):
- *   "Round 1 — a random player is chosen as the first taker.
- *    Round 2+ — players take turns in the order they were entered on the
+ *   "Round 1 — a random player is chosen as the first dealer.
+ *    Round 2+ — players take turns dealing in the order they were entered on the
  *    setup screen, cycling back to the first player after the last one."
  *
- * The formula used in GameScreen is:
- *   currentTakerIndex = (startingIndex + currentRound - 1) % playerNames.size
+ * Important: the dealer distributes the cards but does NOT automatically become
+ * the attacker. Any player can bid for the contract; the player with the highest
+ * bid becomes the attacker (taker) and is selected explicitly in the UI (issue #124).
+ *
+ * The formula used in GameViewModel is:
+ *   currentDealerIndex = (startingIndex + currentRound - 1) % playerNames.size
  *
  * Because this is pure integer arithmetic we can test it here on the JVM
  * without needing a device or Compose — we just mirror the formula.
@@ -21,71 +25,71 @@ import org.junit.Test
 class TakerRotationTest {
 
     /**
-     * Mirrors the formula from GameScreen.kt exactly.
+     * Mirrors the formula from GameViewModel.currentDealer exactly.
      * If the formula ever changes there, this test will catch the divergence.
      */
-    private fun takerIndex(startingIndex: Int, round: Int, playerCount: Int): Int =
+    private fun dealerIndex(startingIndex: Int, round: Int, playerCount: Int): Int =
         (startingIndex + round - 1) % playerCount
 
     // ── Basic rotation with 3 players ─────────────────────────────────────────
 
     @Test
     fun `starting at index 0 with 3 players cycles 0-1-2-0`() {
-        assertEquals(0, takerIndex(startingIndex = 0, round = 1, playerCount = 3))
-        assertEquals(1, takerIndex(startingIndex = 0, round = 2, playerCount = 3))
-        assertEquals(2, takerIndex(startingIndex = 0, round = 3, playerCount = 3))
-        assertEquals(0, takerIndex(startingIndex = 0, round = 4, playerCount = 3)) // wraps
+        assertEquals(0, dealerIndex(startingIndex = 0, round = 1, playerCount = 3))
+        assertEquals(1, dealerIndex(startingIndex = 0, round = 2, playerCount = 3))
+        assertEquals(2, dealerIndex(startingIndex = 0, round = 3, playerCount = 3))
+        assertEquals(0, dealerIndex(startingIndex = 0, round = 4, playerCount = 3)) // wraps
     }
 
     @Test
     fun `starting at index 1 with 3 players cycles 1-2-0-1`() {
-        assertEquals(1, takerIndex(startingIndex = 1, round = 1, playerCount = 3))
-        assertEquals(2, takerIndex(startingIndex = 1, round = 2, playerCount = 3))
-        assertEquals(0, takerIndex(startingIndex = 1, round = 3, playerCount = 3)) // wraps
-        assertEquals(1, takerIndex(startingIndex = 1, round = 4, playerCount = 3)) // full cycle
+        assertEquals(1, dealerIndex(startingIndex = 1, round = 1, playerCount = 3))
+        assertEquals(2, dealerIndex(startingIndex = 1, round = 2, playerCount = 3))
+        assertEquals(0, dealerIndex(startingIndex = 1, round = 3, playerCount = 3)) // wraps
+        assertEquals(1, dealerIndex(startingIndex = 1, round = 4, playerCount = 3)) // full cycle
     }
 
     @Test
     fun `starting at last index wraps to first on round 2`() {
         // 3 players, last index = 2
-        assertEquals(2, takerIndex(startingIndex = 2, round = 1, playerCount = 3))
-        assertEquals(0, takerIndex(startingIndex = 2, round = 2, playerCount = 3)) // wraps immediately
-        assertEquals(1, takerIndex(startingIndex = 2, round = 3, playerCount = 3))
+        assertEquals(2, dealerIndex(startingIndex = 2, round = 1, playerCount = 3))
+        assertEquals(0, dealerIndex(startingIndex = 2, round = 2, playerCount = 3)) // wraps immediately
+        assertEquals(1, dealerIndex(startingIndex = 2, round = 3, playerCount = 3))
     }
 
     // ── Rotation with 5 players ───────────────────────────────────────────────
 
     @Test
     fun `full 5-player cycle starting at index 2`() {
-        assertEquals(2, takerIndex(startingIndex = 2, round = 1, playerCount = 5))
-        assertEquals(3, takerIndex(startingIndex = 2, round = 2, playerCount = 5))
-        assertEquals(4, takerIndex(startingIndex = 2, round = 3, playerCount = 5))
-        assertEquals(0, takerIndex(startingIndex = 2, round = 4, playerCount = 5))
-        assertEquals(1, takerIndex(startingIndex = 2, round = 5, playerCount = 5))
-        assertEquals(2, takerIndex(startingIndex = 2, round = 6, playerCount = 5)) // full cycle
+        assertEquals(2, dealerIndex(startingIndex = 2, round = 1, playerCount = 5))
+        assertEquals(3, dealerIndex(startingIndex = 2, round = 2, playerCount = 5))
+        assertEquals(4, dealerIndex(startingIndex = 2, round = 3, playerCount = 5))
+        assertEquals(0, dealerIndex(startingIndex = 2, round = 4, playerCount = 5))
+        assertEquals(1, dealerIndex(startingIndex = 2, round = 5, playerCount = 5))
+        assertEquals(2, dealerIndex(startingIndex = 2, round = 6, playerCount = 5)) // full cycle
     }
 
-    // ── Invariant: every player takes exactly once per cycle ──────────────────
+    // ── Invariant: every player deals exactly once per cycle ──────────────────
 
     @Test
-    fun `every player takes exactly once per cycle regardless of starting index`() {
+    fun `every player deals exactly once per cycle regardless of starting index`() {
         // Spec: players cycle through "in the order they were entered".
-        // This means each player appears exactly once per N-round cycle.
+        // This means each player deals exactly once per N-round cycle.
         for (playerCount in 3..5) {                  // test all valid player counts
             for (startingIndex in 0 until playerCount) {
                 val indicesInCycle = (1..playerCount).map { round ->
-                    takerIndex(startingIndex, round, playerCount)
+                    dealerIndex(startingIndex, round, playerCount)
                 }
                 assertEquals(
                     "playerCount=$playerCount startingIndex=$startingIndex: " +
-                    "every player should take exactly once per $playerCount-round cycle",
+                    "every player should deal exactly once per $playerCount-round cycle",
                     (0 until playerCount).toSet(),
                     indicesInCycle.toSet()
                 )
                 // Also verify no duplicates within the cycle.
                 assertEquals(
                     "playerCount=$playerCount startingIndex=$startingIndex: " +
-                    "no player should take twice in the same cycle",
+                    "no player should deal twice in the same cycle",
                     playerCount,
                     indicesInCycle.distinct().size
                 )
@@ -94,30 +98,30 @@ class TakerRotationTest {
     }
 
     @Test
-    fun `round 1 taker index equals the starting index`() {
-        // Spec: "Round 1 — a random player is chosen as the first taker."
+    fun `round 1 dealer index equals the starting index`() {
+        // Spec: "Round 1 — a random player is chosen as the first dealer."
         // Whatever the random starting index is, round 1 must show that player.
         for (playerCount in 3..5) {
             for (startingIndex in 0 until playerCount) {
                 assertEquals(
-                    "Round 1 taker should always be the player at startingIndex",
+                    "Round 1 dealer should always be the player at startingIndex",
                     startingIndex,
-                    takerIndex(startingIndex, round = 1, playerCount)
+                    dealerIndex(startingIndex, round = 1, playerCount)
                 )
             }
         }
     }
 
     @Test
-    fun `round 2 taker is the next player in setup order`() {
-        // Spec: "Round 2+ — players take turns in the order they were entered."
+    fun `round 2 dealer is the next player in setup order`() {
+        // Spec: "Round 2+ — players take turns dealing in the order they were entered."
         for (playerCount in 3..5) {
             for (startingIndex in 0 until playerCount) {
                 val expectedRound2Index = (startingIndex + 1) % playerCount
                 assertEquals(
-                    "Round 2 taker should be the player immediately after the starting player",
+                    "Round 2 dealer should be the player immediately after the starting player",
                     expectedRound2Index,
-                    takerIndex(startingIndex, round = 2, playerCount)
+                    dealerIndex(startingIndex, round = 2, playerCount)
                 )
             }
         }

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -20,20 +20,29 @@ After setting up players on the setup screen, the user taps **Start Game** to be
 | Concern | Where it lives |
 |---|---|
 | Game session state (`currentRound`, `roundHistory`) | `GameViewModel` |
-| `recordPlayed`, `recordSkipped`, `endGame` | `GameViewModel` |
-| Contract selection, overlay visibility | `GameScreen` (local `remember` state) |
+| `recordPlayed(takerName, contract, details)`, `recordSkipped`, `endGame` | `GameViewModel` |
+| Dealer rotation (`currentDealer`) | `GameViewModel` |
+| Attacker selection, contract selection, overlay visibility | `GameScreen` (local `remember` state) |
 | Sub-composables (`CompactBonusGrid`, `PlayerChipSelector`, etc.) | `UiComponents.kt` |
 
-The game is divided into **rounds**. The taker for each round is determined automatically:
+The game is divided into **rounds**. Each round has two distinct roles:
 
-- **Round 1** — a random player is chosen as the first taker.
-- **Round 2+** — players take turns in the order they were entered on the setup screen, cycling back to the first player after the last one.
+- **Dealer** — deals the cards. The dealer role rotates each round:
+  - **Round 1**: a random player is chosen as the first dealer.
+  - **Round 2+**: players take turns dealing in the order they were entered on the setup screen, cycling back to the first player after the last one.
+- **Attacker (taker / preneur)** — the player who wins the bidding and takes the contract. *Any* player can bid for the contract regardless of who deals. The player with the highest bid becomes the attacker and their score is affected by the round outcome.
 
-Everything is presented on **a single scrollable page**: the compact scoreboard, the contract chips, the inline details form, and the round history log are all visible without navigating to a separate screen.
+The current dealer's name is shown at the top of the round section for reference. The user then selects the attacker by tapping any player's name in the segmented-button row.
+
+Everything is presented on **a single scrollable page**: the compact scoreboard, the dealer label, the attacker selector, the contract chips, the inline details form, and the round history log are all visible without navigating to a separate screen.
+
+#### Attacker selection
+
+A segmented-button row listing every player's name is shown above the contract chips. The user taps the player who won the bidding to select them as the attacker. Tapping the same player again deselects them. The **Confirm round** button stays disabled until an attacker is selected (in addition to a contract and a score).
 
 #### Contract selection
 
-The current taker's name is shown above a row of FilterChips — one per contract (weakest → strongest):
+Once an attacker is selected, a prompt shows their name above a row of SegmentedButtons — one per contract (weakest → strongest):
 
 | Contract (FR) | Contract (EN)  | Multiplier | Description                    |
 |---------------|----------------|:----------:|-------------------------------|
@@ -226,6 +235,8 @@ The bar is a direct child of the outer (non-scrollable) `Column`, which also own
 
 ## Data Model
 
+- **`currentDealer: String`** (read-only property on `GameViewModel`) — the name of the player who deals cards this round, computed by `(startingIndex + currentRound − 1) % playerCount`. This is separate from the attacker, which is chosen by the user each round.
+- **`recordPlayed(takerName, contract, details)`** — accepts an explicit `takerName` parameter (the attacker) rather than deriving it from the dealer rotation. This ensures scores are always attributed to the player who won the bidding.
 - `Contract` enum — four contracts with `displayName` and `multiplier`.
 - `Chelem` enum — five grand slam outcomes (`NONE`, `ANNOUNCED_REALIZED`, `ANNOUNCED_NOT_REALIZED`, `NOT_ANNOUNCED_REALIZED`, `DEFENDERS_REALIZED`). The last entry covers the FFT-official defenders-chelem scenario (R-RO201206.pdf p.6).
 - `RoundDetails` data class — all scoring fields: bouts, points, `partnerName` (5-player only), player-assigned bonuses, the chelem outcome, and `chelemPlayer` (which player called/achieved the chelem — null when `chelem == NONE`).


### PR DESCRIPTION
## Summary

- **Bug**: Points were being attributed to the dealer (the player whose turn it was to distribute cards) instead of to the attacker (the player who won the bidding and took the contract).
- **Fix**: Separated the *dealer* role (which rotates automatically) from the *attacker* role (which any player can take by winning the bid).
- A new attacker-selector row (`SingleChoiceSegmentedButtonRow` with all player names) is shown above the contract chips. The user taps the player who won the bidding. The **Confirm round** button stays disabled until an attacker is selected.
- `GameViewModel.currentTaker` → renamed to `currentDealer` to correctly reflect what the rotation formula computes.
- `recordPlayed()` now takes an explicit `takerName: String` parameter instead of deriving it from the dealer rotation internally.

## Test plan

- [ ] Unit tests: `./gradlew testDebugUnitTest` — all pass
- [ ] Mutation score: `./gradlew pitest` — 81% (gate: 80%)
- [ ] Lint: `./gradlew lint` — no new warnings
- [ ] New UI tests verify: attacker selector visible, Confirm disabled without attacker, Confirm enabled after attacker + contract + score, attacker resets after each round
- [ ] Manual: select any player as attacker (not just the dealer shown in the label) and confirm the round → history row shows the selected player's name