### PR TITLE
feat(114): add 'Points (0-91)' label to points input field

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -482,6 +482,21 @@ class GameScreenTest {
         composeTestRule.onNodeWithText("Round 1").assertIsDisplayed()
     }
 
+    // ── Spec: points field label (issue #114) ────────────────────────────────
+
+    @Test
+    fun points_input_shows_label_with_range() {
+        // The label "Points (0-91)" must be visible on the field so users know
+        // what values to enter without needing an external hint.
+        launchGame()
+        selectAttacker()
+        composeTestRule.onNodeWithText("Garde").performClick()
+
+        composeTestRule
+            .onNodeWithText(EnStrings.pointsLabel)
+            .assertIsDisplayed()
+    }
+
     // ── Spec: points field validation (issue #8) ──────────────────────────────
 
     @Test

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -82,6 +82,8 @@ data class AppStrings(
     val doublePoigneeTooltipBody: (playerCount: Int) -> String,
     val triplePoigneeTooltipBody: (playerCount: Int) -> String,
     val chelemTooltipBody: String,
+    // Label shown inside the points text field so users know the field's purpose and valid range.
+    val pointsLabel: String,
     // Error shown below the points text field when the entered value exceeds 91.
     val pointsOutOfRange: String,
     // Confirmation dialog for "Skip round".
@@ -195,6 +197,7 @@ val EnStrings = AppStrings(
     doublePoigneeTooltipBody = { n -> "${poigneeThresholds(n).second} trumps shown before play.\nBonus: 30 pts per player." },
     triplePoigneeTooltipBody = { n -> "${poigneeThresholds(n).third} trumps shown before play.\nBonus: 40 pts per player." },
     chelemTooltipBody     = "All tricks won by the same team.\n\nAnnounced & realized: +400 pts\nNot announced, realized: +200 pts\nAnnounced, not realized: −200 pts\nDefenders realized: −200 pts (taker pays each defender)",
+    pointsLabel           = "Points (0-91)",
     pointsOutOfRange      = "Must be between 0 and 91",
     skipRoundConfirmTitle = "Skip this round?",
     skipRoundConfirmBody  = "No contract will be recorded for this round.",
@@ -283,6 +286,7 @@ val FrStrings = AppStrings(
     doublePoigneeTooltipBody = { n -> "${poigneeThresholds(n).second} atouts déclarés avant le jeu.\nBonus : 30 pts par joueur." },
     triplePoigneeTooltipBody = { n -> "${poigneeThresholds(n).third} atouts déclarés avant le jeu.\nBonus : 40 pts par joueur." },
     chelemTooltipBody     = "Tous les plis remportés par la même équipe.\n\nAnnoncé et réalisé : +400 pts\nNon annoncé, réalisé : +200 pts\nAnnoncé, non réalisé : −200 pts\nDéfense réalise : −200 pts (le preneur paye chaque défenseur)",
+    pointsLabel           = "Points (0-91)",
     pointsOutOfRange      = "Doit être entre 0 et 91",
     skipRoundConfirmTitle = "Passer ce tour ?",
     skipRoundConfirmBody  = "Aucun contrat ne sera enregistré pour ce tour.",

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -477,9 +477,9 @@ fun GameScreen(
                             keyboardActions = KeyboardActions(
                                 onDone = { keyboardController?.hide() }
                             ),
-                            // Show the valid range as a placeholder so the user knows
-                            // what values are accepted without a separate hint.
-                            placeholder     = { Text("0-91") },
+                            // Floating label names the field and shows the valid range
+                            // so users always know what to enter without needing a tooltip.
+                            label           = { Text(strings.pointsLabel) },
                             isError         = pointsError,
                             supportingText  = if (pointsError) ({
                                 Text(

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -64,7 +64,7 @@ Tapping the active chip again collapses the form and deselects the contract.
 |--------------------|-----------------------------|-------------|
 | Bouts (oudlers)    | Dropdown (0 / 1 / 2 / 3)   | Number of oudlers in the taker's tricks |
 | Points mode        | Radio buttons (Taker / Defenders) | Choose which camp's points to enter. The total always sums to 91, so entering defender points is equivalent. |
-| Points             | Number input (0–91)         | Points scored by the selected camp. When "Defenders" is chosen the app converts to taker points on confirm (`takerPoints = 91 − defenderPoints`). Values outside 0–91 show an error and disable the Confirm button. |
+| Points             | Number input — label **"Points (0-91)"** | Points scored by the selected camp. The floating label names the field and shows the valid range (0–91) so users always know what to enter. When "Defenders" is chosen the app converts to taker points on confirm (`takerPoints = 91 − defenderPoints`). Values outside 0–91 show an error and disable the Confirm button. |
 | Partner            | None or any player (5-player only) | The player called by the taker as a silent partner |
 | Petit au bout      | Checkbox per player         | Player who captured the 1 of trump on the last trick |
 | Poignée            | Checkbox per player         | Player who showed a simple Poignée (see thresholds below) |


### PR DESCRIPTION
## Summary

- Adds a `pointsLabel` string (`"Points (0-91)"`) to `AppStrings` for both EN and FR locales
- Wires it as a floating `label` on the points `OutlinedTextField` in `GameScreen`, replacing the bare placeholder — users can now always see the field's purpose and valid range
- Adds a Compose UI test that verifies the label is displayed after a contract is selected

## Test plan

- [ ] Run `./gradlew testDebugUnitTest` — all 24 unit tests pass
- [ ] Run `./gradlew pitest` — mutation score 81% (above 80% gate)
- [ ] Run `./gradlew lint` — no new warnings
- [ ] Run `./gradlew connectedAndroidTest` on a device/emulator — new `points_input_shows_label_with_range` test should pass

Closes #114