### PR TITLE
fix(131): hide contract selector until attacker is selected

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -123,8 +123,19 @@ class GameScreenTest {
     // ── Spec: Step 1 — four contract buttons ─────────────────────────────────
 
     @Test
-    fun all_four_contract_buttons_are_displayed() {
+    fun contract_buttons_hidden_before_attacker_is_selected() {
+        // Issue #131: contract buttons must not appear until the attacker is chosen.
         launchGame()
+        Contract.entries.forEach { contract ->
+            composeTestRule.onNodeWithText(contract.displayName).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun all_four_contract_buttons_are_displayed() {
+        // Contract buttons only appear after the attacker is selected (issue #131).
+        launchGame()
+        selectAttacker()
         Contract.entries.forEach { contract ->
             composeTestRule.onNodeWithText(contract.displayName).assertIsDisplayed()
         }
@@ -132,7 +143,9 @@ class GameScreenTest {
 
     @Test
     fun pousse_button_does_not_exist() {
+        // Even after selecting an attacker, "Pousse" must never appear.
         launchGame()
+        selectAttacker()
         composeTestRule.onNodeWithText("Pousse").assertDoesNotExist()
     }
 
@@ -165,7 +178,10 @@ class GameScreenTest {
     @Test
     fun confirm_button_remains_disabled_when_contract_selected_but_no_score_entered() {
         // Spec: contract alone is not enough — a score value must also be typed.
+        // An attacker must be selected first because contract buttons are hidden until then
+        // (issue #131).
         launchGame()
+        selectAttacker()
         composeTestRule.onNodeWithText("Garde").performClick()
         composeTestRule.onNodeWithText("Confirm round").assertIsNotEnabled()
     }

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -323,45 +323,49 @@ fun GameScreen(
             // SingleChoiceSegmentedButtonRow is the Material 3 standard for picking
             // one option from a fixed set. Tapping the already-selected segment
             // deselects it (collapses the details form).
-            if (selectedAttacker != null) {
-            Text(
-                text = strings.chooseContract(selectedAttacker!!),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.align(Alignment.Start)
-            )
-            Spacer(Modifier.height(8.dp))
-            } // end attacker-required guard
 
-            // Shared font size — all 4 segments shrink together so they always display
-            // at the same size (the smallest needed across the longest label).
-            // Keyed on locale so labels re-measure whenever the language changes.
+            // rememberSharedAutoSizeState must be called unconditionally (Compose rule:
+            // remember calls must not be placed inside if/when/loop branches).
+            // The value is only *used* inside the if-block below.
             val contractLabelSize = rememberSharedAutoSizeState(locale)
 
-            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
-                Contract.entries.forEachIndexed { index, c ->
-                    SegmentedButton(
-                        // shape draws the correct rounded corners: round on the outer ends,
-                        // straight on the inner edges between segments.
-                        shape    = SegmentedButtonDefaults.itemShape(
-                            index = index,
-                            count = Contract.entries.size
-                        ),
-                        selected = selectedContract == c,
-                        onClick  = { selectedContract = if (selectedContract == c) null else c },
-                        // Hide the checkmark icon — the filled/outlined segment already
-                        // communicates selection clearly.
-                        icon     = {}
-                    ) {
-                        AutoSizeText(
-                            text            = c.localizedName(locale),
-                            modifier        = Modifier.padding(horizontal = 1.dp),
-                            sharedSizeState = contractLabelSize
-                        )
+            if (selectedAttacker != null) {
+                Text(
+                    text = strings.chooseContract(selectedAttacker!!),
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.align(Alignment.Start)
+                )
+                Spacer(Modifier.height(8.dp))
+
+                // Shared font size — all 4 segments shrink together so they always display
+                // at the same size (the smallest needed across the longest label).
+                // Keyed on locale so labels re-measure whenever the language changes.
+                SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                    Contract.entries.forEachIndexed { index, c ->
+                        SegmentedButton(
+                            // shape draws the correct rounded corners: round on the outer ends,
+                            // straight on the inner edges between segments.
+                            shape    = SegmentedButtonDefaults.itemShape(
+                                index = index,
+                                count = Contract.entries.size
+                            ),
+                            selected = selectedContract == c,
+                            onClick  = { selectedContract = if (selectedContract == c) null else c },
+                            // Hide the checkmark icon — the filled/outlined segment already
+                            // communicates selection clearly.
+                            icon     = {}
+                        ) {
+                            AutoSizeText(
+                                text            = c.localizedName(locale),
+                                modifier        = Modifier.padding(horizontal = 1.dp),
+                                sharedSizeState = contractLabelSize
+                            )
+                        }
                     }
                 }
-            }
 
-            Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(8.dp))
+            } // end attacker-required guard
 
             // ── Inline round details ──────────────────────────────────────────
             // The form state (bouts, pointsText, etc.) is declared at the top of

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -42,6 +42,8 @@ A segmented-button row listing every player's name is shown above the contract c
 
 #### Contract selection
 
+The contract selector is **only shown after an attacker has been selected** (issue #131). This avoids presenting irrelevant information before the bidding winner is known.
+
 Once an attacker is selected, a prompt shows their name above a row of SegmentedButtons — one per contract (weakest → strongest):
 
 | Contract (FR) | Contract (EN)  | Multiplier | Description                    |


### PR DESCRIPTION
## Summary

- The contract segmented-button row was always rendered, even before an attacking player was chosen
- The entire contract section (title label + buttons) is now guarded by `if (selectedAttacker != null)`
- `rememberSharedAutoSizeState` remains unconditional to comply with Compose's rule against conditional `remember` calls

## Tests

- Added `contract_buttons_hidden_before_attacker_is_selected` to cover the regression case directly
- Updated `all_four_contract_buttons_are_displayed`, `pousse_button_does_not_exist`, and `confirm_button_remains_disabled_when_contract_selected_but_no_score_entered` to select an attacker first (required now that contract buttons are hidden initially)
- Mutation score: 81% (gate: 80%) ✅

## Test plan

- [ ] Launch the game — confirm no contract buttons are visible
- [ ] Select an attacker — confirm all four contract buttons appear with the attacker's name in the prompt
- [ ] Deselect the attacker — confirm contract buttons disappear again
- [ ] Complete a full round to confirm end-to-end flow is unaffected

Closes #131