### PR TITLE
feat(120): add settings page for theme, language, and contact options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Android app for tracking scores in **French Tarot**, a classic French trick-t
 
 TarotCounter guides players through a game round by round:
 
-1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap ☀️ or 🌙 in the top-left to toggle between light and dark mode (persisted across restarts, defaults to light); tap 🇬🇧 or 🇫🇷 in the top-right to switch the app language (persisted across restarts, defaults to device language)
+1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap the **⚙ gear icon** (top-right) to open the Settings page
 2. **Attacker selection + contract** — tap the player who won the bidding to set them as the **attacker** (any player can bid, not just the dealer); then pick their contract; the dealer label shows who is distributing the cards this round; a persistent **bottom action bar** always shows **End Game** (left) and **Skip round** (right) for quick access
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
 4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first; each history row shows a colored **●** indicator (green = won, red = lost, grey = skipped) for at-a-glance scanning
@@ -16,7 +16,7 @@ TarotCounter guides players through a game round by round:
 8. **Auto-save & Resume** — the game state is saved after every round; if the app is closed mid-game, a "Resume Game" card appears on the setup screen the next time it is opened
 9. **Past Games** — completed games are saved to the device; the setup screen shows a list of past results with a trophy icon next to the winner's name
 10. **Back navigation** — the Android system back button always returns to the landing page; on the Final Score screen a confirmation dialog is shown first to avoid accidentally losing unsaved results
-11. **Feedback button** — a "Send Feedback" / "Contacter le développeur" button at the bottom of the setup screen opens the device's email client pre-addressed to the developer
+11. **Settings page** — a dedicated settings page (reachable via the ⚙ gear icon on the setup screen) consolidates theme toggle (☀️ / 🌙), language toggle (🇬🇧 / 🇫🇷), and a feedback button that opens the device's email client pre-addressed to the developer; both theme and language are persisted across restarts
 
 The app rotates the **dealer** each round and lets the user explicitly select the **attacker** (the player who won the bidding), determines win/loss, and computes each player's score for the round.
 
@@ -74,6 +74,7 @@ app/src/main/java/fr/mandarine/tarotcounter/
 ├── LandingScreen.kt       # Player setup UI + Past Games list
 ├── GameScreen.kt          # Round management, taker rotation, details form, history, End Game button
 ├── ScreenHeader.kt        # Shared back-arrow header composable
+├── SettingsScreen.kt      # Settings page: theme, language, feedback
 ├── ScoreHistoryScreen.kt  # Round-by-round cumulative score table
 ├── FinalScoreScreen.kt    # End-of-game results: winner card + full score table
 ├── UiComponents.kt        # Shared UI: AppButton, AppOutlinedButton, AppTextButton, AutoSizeText
@@ -189,7 +190,8 @@ manual retrace instructions, and where to view crash reports in Play Console.
 | `TakerRotationTest.kt` | Taker rotation formula for 3–5 players |
 | `AppLocaleTest.kt` | i18n string bundles: locale-specific strings, lambda formatters, enum localized names |
 | `GameViewModelTest.kt` | ViewModel: locale + theme StateFlows, `setLocale`, `setTheme`, `saveGame`, `clearInProgressGame` |
-| `LandingScreenTest.kt` | Setup screen UI: player count chips, name fields, duplicate validation, theme toggle chips, feedback button |
+| `LandingScreenTest.kt` | Setup screen UI: player count chips, name fields, duplicate validation, settings gear icon |
+| `SettingsScreenTest.kt` | Settings page: back navigation, theme toggle, language toggle, feedback button, section labels |
 | `GameScreenTest.kt` | Full game flow: contract selection, details form, history, score history navigation, End Game button |
 | `ScoreHistoryScreenTest.kt` | Score history table: column headers, cumulative totals, back navigation |
 | `FinalScoreScreenTest.kt` | Final score screen: winner card, tie detection, score table, New Game navigation |
@@ -208,6 +210,7 @@ TarotCounter/
 │   ├── ui-components.md      # Shared UI components: AppButton, AutoSizeText guideline
 │   ├── game-flow.md          # Game mechanics specification
 │   ├── player-setup.md       # Setup screen behaviour
+│   ├── settings.md           # Settings page: theme, language, feedback
 │   ├── score-history.md      # Score history table
 │   ├── final-score.md        # Final score screen: winner card, End Game flow
 │   ├── game-persistence.md   # How completed games are saved and displayed
@@ -231,6 +234,7 @@ More detailed documentation lives in [`docs/`](docs/):
 - [`docs/ui-components.md`](docs/ui-components.md) — shared UI building blocks: `AppButton`, `AutoSizeText`, and the button convention
 - [`docs/game-flow.md`](docs/game-flow.md) — complete game mechanics, data models, round history format
 - [`docs/player-setup.md`](docs/player-setup.md) — setup screen behaviour and validation rules
+- [`docs/settings.md`](docs/settings.md) — settings page: theme toggle, language toggle, feedback button, navigation wiring
 - [`docs/score-history.md`](docs/score-history.md) — score history table: layout, navigation, scrolling
 - [`docs/final-score.md`](docs/final-score.md) — final score screen: winner card, table highlighting, New Game navigation
 - [`docs/game-persistence.md`](docs/game-persistence.md) — how completed games are saved to DataStore and displayed on the setup screen

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -239,6 +239,7 @@ afterEvaluate {
                 "fr.mandarine.tarotcounter.ScoreHistoryScreenKt*," +
                 "fr.mandarine.tarotcounter.UiComponentsKt*," +
                 "fr.mandarine.tarotcounter.ScreenHeaderKt*," +
+                "fr.mandarine.tarotcounter.SettingsScreenKt*," +
                 // BonusRow is a composable compiled to its own class (lives in UiComponents.kt)
                 "fr.mandarine.tarotcounter.BonusRow*," +
                 // Compose compiler-generated singletons

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith
  *   - Choose 3–5 players via filter chips.
  *   - Enter optional names for each player.
  *   - Tap Start Game to lock in names and navigate to the game screen.
+ *   - Tap the gear icon to navigate to the Settings page.
  */
 @RunWith(AndroidJUnit4::class)
 class LandingScreenTest {
@@ -38,17 +39,17 @@ class LandingScreenTest {
 
     /**
      * Launches LandingScreen inside our app theme (same as production).
-     * [onThemeChange] captures the AppTheme passed to the callback when a chip is tapped.
+     * [onNavigateToSettings] captures whether the settings gear was tapped.
      */
     private fun launch(
         onStartGame: (List<String>) -> Unit = {},
-        onThemeChange: (AppTheme) -> Unit = {}
+        onNavigateToSettings: () -> Unit = {}
     ) {
         composeTestRule.setContent {
             TarotCounterTheme {
                 LandingScreen(
-                    onStartGame   = onStartGame,
-                    onThemeChange = onThemeChange
+                    onStartGame          = onStartGame,
+                    onNavigateToSettings = onNavigateToSettings
                 )
             }
         }
@@ -82,14 +83,23 @@ class LandingScreenTest {
         composeTestRule.onNodeWithText("Tarot Counter").assertIsDisplayed()
     }
 
-    // ── Spec: language switcher is shown ──────────────────────────────────────
+    // ── Spec: settings gear icon is shown ────────────────────────────────────
 
     @Test
-    fun language_switcher_shows_both_flags() {
+    fun settings_gear_icon_is_displayed() {
         launch()
-        // Both flag emoji chips must be present on the landing screen.
-        composeTestRule.onNodeWithText("🇬🇧").assertIsDisplayed()
-        composeTestRule.onNodeWithText("🇫🇷").assertIsDisplayed()
+        // The gear icon has contentDescription = strings.settings = "Settings".
+        composeTestRule.onNodeWithContentDescription("Settings").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_settings_icon_calls_onNavigateToSettings() {
+        var called = false
+        launch(onNavigateToSettings = { called = true })
+
+        composeTestRule.onNodeWithContentDescription("Settings").performClick()
+
+        assert(called) { "Expected onNavigateToSettings to be called when gear icon is tapped" }
     }
 
     // ── Spec: player-count chips 3, 4, 5 ─────────────────────────────────────
@@ -311,69 +321,6 @@ class LandingScreenTest {
         composeTestRule.onNodeWithText("Past Games").assertIsDisplayed()
     }
 
-    // ── Spec: theme toggle chips are shown ────────────────────────────────────
-
-    @Test
-    fun theme_toggle_shows_both_sun_and_moon_chips() {
-        launch()
-        // Both emoji chips must be present in the header row.
-        composeTestRule.onNodeWithText("☀️").assertIsDisplayed()
-        composeTestRule.onNodeWithText("🌙").assertIsDisplayed()
-    }
-
-    @Test
-    fun tapping_moon_chip_calls_onThemeChange_with_DARK() {
-        var capturedTheme: AppTheme? = null
-        launch(onThemeChange = { capturedTheme = it })
-
-        composeTestRule.onNodeWithText("🌙").performClick()
-
-        assertEquals(AppTheme.DARK, capturedTheme)
-    }
-
-    @Test
-    fun tapping_sun_chip_calls_onThemeChange_with_LIGHT() {
-        var capturedTheme: AppTheme? = null
-        launch(onThemeChange = { capturedTheme = it })
-
-        composeTestRule.onNodeWithText("☀️").performClick()
-
-        assertEquals(AppTheme.LIGHT, capturedTheme)
-    }
-
-    // ── Spec: segmented button selection state (issue #101) ──────────────────
-    // The theme and language toggles now use SingleChoiceSegmentedButtonRow.
-    // Compose exposes the selected state via the `Selected` semantics property,
-    // which we can assert with `assertIsSelected()` / `assertIsNotSelected()`.
-
-    @Test
-    fun tapping_locale_fr_calls_onLocaleChange_with_FR() {
-        var capturedLocale: AppLocale? = null
-        composeTestRule.setContent {
-            TarotCounterTheme {
-                LandingScreen(onLocaleChange = { capturedLocale = it })
-            }
-        }
-
-        composeTestRule.onNodeWithText("🇫🇷").performClick()
-
-        assertEquals(AppLocale.FR, capturedLocale)
-    }
-
-    @Test
-    fun tapping_locale_en_calls_onLocaleChange_with_EN() {
-        var capturedLocale: AppLocale? = null
-        composeTestRule.setContent {
-            TarotCounterTheme {
-                LandingScreen(onLocaleChange = { capturedLocale = it })
-            }
-        }
-
-        composeTestRule.onNodeWithText("🇬🇧").performClick()
-
-        assertEquals(AppLocale.EN, capturedLocale)
-    }
-
     // ── Spec: past game card shows winner name (issue #5) ─────────────────────
 
     @Test
@@ -384,35 +331,4 @@ class LandingScreenTest {
         composeTestRule.onNodeWithText("Alice", substring = true).assertIsDisplayed()
     }
 
-    // ── Spec: feedback button (issue #72) ─────────────────────────────────────
-
-    @Test
-    fun feedback_button_is_displayed() {
-        launch()
-        composeTestRule.onNodeWithText("Send Feedback").assertIsDisplayed()
-    }
-
-    @Test
-    fun feedback_button_is_below_start_game_button() {
-        launch()
-        val startBounds    = composeTestRule.onNodeWithText("Start Game").getBoundsInRoot()
-        val feedbackBounds = composeTestRule.onNodeWithText("Send Feedback").getBoundsInRoot()
-
-        assert(feedbackBounds.top >= startBounds.bottom) {
-            "Expected Send Feedback button (top=${feedbackBounds.top}) to be below " +
-                "Start Game button (bottom=${startBounds.bottom})"
-        }
-    }
-
-    @Test
-    fun feedback_button_is_below_past_games_section() {
-        launchWithPastGames()
-        val feedbackBounds  = composeTestRule.onNodeWithText("Send Feedback").getBoundsInRoot()
-        val pastGamesBounds = composeTestRule.onNodeWithText("Past Games").getBoundsInRoot()
-
-        assert(feedbackBounds.top >= pastGamesBounds.bottom) {
-            "Expected Send Feedback button (top=${feedbackBounds.top}) to be below " +
-                "Past Games heading (bottom=${pastGamesBounds.bottom})"
-        }
-    }
 }

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/SettingsScreenTest.kt
@@ -1,0 +1,177 @@
+package fr.mandarine.tarotcounter
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * UI tests for SettingsScreen.
+ *
+ * These run on a device or emulator via AndroidJUnit4.
+ * Run with: ./gradlew connectedAndroidTest
+ *
+ * Spec (docs/settings.md):
+ *   - Shows a back arrow that calls onBack when tapped.
+ *   - Shows the screen title "Settings".
+ *   - Shows theme toggle (☀️ / 🌙) and calls onThemeChange when tapped.
+ *   - Shows language toggle (🇬🇧 / 🇫🇷) and calls onLocaleChange when tapped.
+ *   - Shows the developer feedback button.
+ */
+@RunWith(AndroidJUnit4::class)
+class SettingsScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /**
+     * Launches SettingsScreen wrapped in the app theme and optionally a custom locale/theme.
+     * The [CompositionLocalProvider] mirrors what MainActivity does so the screen
+     * reads the current locale and theme the same way as in production.
+     */
+    private fun launch(
+        locale: AppLocale = AppLocale.EN,
+        theme: AppTheme = AppTheme.LIGHT,
+        onThemeChange: (AppTheme) -> Unit = {},
+        onLocaleChange: (AppLocale) -> Unit = {},
+        onBack: () -> Unit = {}
+    ) {
+        composeTestRule.setContent {
+            TarotCounterTheme(darkTheme = theme == AppTheme.DARK) {
+                // Provide locale and theme so SettingsScreen can read them via
+                // LocalAppLocale.current and LocalAppTheme.current.
+                CompositionLocalProvider(
+                    LocalAppLocale provides locale,
+                    LocalAppTheme  provides theme
+                ) {
+                    SettingsScreen(
+                        onThemeChange  = onThemeChange,
+                        onLocaleChange = onLocaleChange,
+                        onBack         = onBack
+                    )
+                }
+            }
+        }
+    }
+
+    // ── Spec: screen title ────────────────────────────────────────────────────
+
+    @Test
+    fun settings_title_is_displayed() {
+        launch()
+        composeTestRule.onNodeWithText("Settings").assertIsDisplayed()
+    }
+
+    @Test
+    fun settings_title_is_displayed_in_french() {
+        launch(locale = AppLocale.FR)
+        composeTestRule.onNodeWithText("Paramètres").assertIsDisplayed()
+    }
+
+    // ── Spec: back navigation ─────────────────────────────────────────────────
+
+    @Test
+    fun tapping_back_arrow_calls_onBack() {
+        var called = false
+        launch(onBack = { called = true })
+
+        // ScreenHeader renders a back arrow with contentDescription = strings.backToGame.
+        composeTestRule.onNodeWithContentDescription("Back to game").performClick()
+
+        assert(called) { "Expected onBack to be called when the back arrow is tapped" }
+    }
+
+    // ── Spec: theme toggle ────────────────────────────────────────────────────
+
+    @Test
+    fun theme_toggle_shows_both_sun_and_moon() {
+        launch()
+        composeTestRule.onNodeWithText("☀️").assertIsDisplayed()
+        composeTestRule.onNodeWithText("🌙").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_moon_calls_onThemeChange_with_DARK() {
+        var captured: AppTheme? = null
+        launch(onThemeChange = { captured = it })
+
+        composeTestRule.onNodeWithText("🌙").performClick()
+
+        assertEquals(AppTheme.DARK, captured)
+    }
+
+    @Test
+    fun tapping_sun_calls_onThemeChange_with_LIGHT() {
+        var captured: AppTheme? = null
+        launch(onThemeChange = { captured = it })
+
+        composeTestRule.onNodeWithText("☀️").performClick()
+
+        assertEquals(AppTheme.LIGHT, captured)
+    }
+
+    // ── Spec: language toggle ─────────────────────────────────────────────────
+
+    @Test
+    fun language_toggle_shows_both_flags() {
+        launch()
+        composeTestRule.onNodeWithText("🇬🇧").assertIsDisplayed()
+        composeTestRule.onNodeWithText("🇫🇷").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_french_flag_calls_onLocaleChange_with_FR() {
+        var captured: AppLocale? = null
+        launch(onLocaleChange = { captured = it })
+
+        composeTestRule.onNodeWithText("🇫🇷").performClick()
+
+        assertEquals(AppLocale.FR, captured)
+    }
+
+    @Test
+    fun tapping_english_flag_calls_onLocaleChange_with_EN() {
+        var captured: AppLocale? = null
+        launch(onLocaleChange = { captured = it })
+
+        composeTestRule.onNodeWithText("🇬🇧").performClick()
+
+        assertEquals(AppLocale.EN, captured)
+    }
+
+    // ── Spec: feedback button ─────────────────────────────────────────────────
+
+    @Test
+    fun feedback_button_is_displayed() {
+        launch()
+        composeTestRule.onNodeWithText("Send Feedback").assertIsDisplayed()
+    }
+
+    @Test
+    fun feedback_button_is_displayed_in_french() {
+        launch(locale = AppLocale.FR)
+        composeTestRule.onNodeWithText("Contacter le développeur").assertIsDisplayed()
+    }
+
+    // ── Spec: section labels ──────────────────────────────────────────────────
+
+    @Test
+    fun theme_section_label_is_displayed() {
+        launch()
+        composeTestRule.onNodeWithText("Theme").assertIsDisplayed()
+    }
+
+    @Test
+    fun language_section_label_is_displayed() {
+        launch()
+        composeTestRule.onNodeWithText("Language").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -132,7 +132,17 @@ data class AppStrings(
     // Confirm action label — distinct from `cancel` which already exists.
     val backConfirmLeave: String,
 
-    // ── Feedback button (Landing Screen) ─────────────────────────────────────
+    // ── Settings ──────────────────────────────────────────────────────────────
+    // Accessibility label for the gear icon button on the landing screen.
+    val settings: String,
+    // Title shown at the top of the settings page.
+    val settingsTitle: String,
+    // Section heading for the theme toggle row on the settings page.
+    val themeLabel: String,
+    // Section heading for the language toggle row on the settings page.
+    val languageLabel: String,
+
+    // ── Feedback button (Settings Screen) ────────────────────────────────────
     // Label for the button that opens the user's email client to contact the developer.
     val feedbackButton: String,
 
@@ -242,6 +252,10 @@ val EnStrings = AppStrings(
     contractGardeSans    = "Guard Without",
     contractGardeContre  = "Guard Against",
 
+    settings                 = "Settings",
+    settingsTitle            = "Settings",
+    themeLabel               = "Theme",
+    languageLabel            = "Language",
     feedbackButton           = "Send Feedback",
 )
 
@@ -331,6 +345,10 @@ val FrStrings = AppStrings(
     contractGardeSans    = "Garde Sans",
     contractGardeContre  = "Garde Contre",
 
+    settings                 = "Paramètres",
+    settingsTitle            = "Paramètres",
+    themeLabel               = "Thème",
+    languageLabel            = "Langue",
     feedbackButton           = "Contacter le développeur",
 )
 

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -1,7 +1,5 @@
 package fr.mandarine.tarotcounter
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,19 +18,19 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -41,7 +39,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,18 +50,16 @@ import java.util.Locale as JavaLocale
 
 // LandingScreen lets the user configure how many players there are and enter their names.
 // It also shows:
-//   - a theme toggle (☀️ / 🌙) in the top-left corner
-//   - a language switcher (🇬🇧 / 🇫🇷) in the top-right corner
+//   - a gear icon button (top-right) that navigates to the Settings page
 //   - a "Resume Game" card (if there is an unfinished game saved from a previous session)
 //   - a "Past Games" list at the bottom (if any games have been completed)
 //
-// onStartGame:     lambda called when the user presses "Start Game" with a list of names.
-// onResumeGame:    lambda called when the user taps "Resume" — passes the saved state back
-//                  to MainActivity so GameScreen can be initialized from it.
-// onLocaleChange:  lambda called when the user taps a flag to switch language.
-// onThemeChange:   lambda called when the user taps ☀️ or 🌙 to switch the theme.
-// inProgressGame:  a game that was interrupted mid-session, or null if there is none.
-// pastGames:       list of completed games; defaults to empty for the @Preview below.
+// onStartGame:          lambda called when the user presses "Start Game" with a list of names.
+// onResumeGame:         lambda called when the user taps "Resume" — passes the saved state back
+//                       to MainActivity so GameScreen can be initialized from it.
+// onNavigateToSettings: lambda called when the user taps the gear icon to open the Settings page.
+// inProgressGame:       a game that was interrupted mid-session, or null if there is none.
+// pastGames:            list of completed games; defaults to empty for the @Preview below.
 @Composable
 fun LandingScreen(
     modifier: Modifier = Modifier,
@@ -72,17 +67,11 @@ fun LandingScreen(
     pastGames: List<SavedGame> = emptyList(),
     onStartGame: (List<String>) -> Unit = {},
     onResumeGame: (InProgressGame) -> Unit = {},
-    onLocaleChange: (AppLocale) -> Unit = {},
-    onThemeChange: (AppTheme) -> Unit = {}
+    onNavigateToSettings: () -> Unit = {}
 ) {
-    // Read the active locale and theme from the composition tree.
+    // Read the active locale from the composition tree.
     val locale  = LocalAppLocale.current
-    val theme   = LocalAppTheme.current
     val strings = appStrings(locale)
-
-    // Context is needed to fire an Android Intent (e.g. open the email client).
-    // LocalContext.current gives us the nearest Activity/Context in the Compose tree.
-    val context = LocalContext.current
 
     // `remember` keeps a value alive across recompositions (UI redraws).
     // `mutableIntStateOf` creates an integer that, when changed, triggers a redraw.
@@ -117,60 +106,23 @@ fun LandingScreen(
         verticalArrangement = Arrangement.Top
     ) {
 
-        // ── Header row: theme toggle (left) + language switcher (right) ──────────
-        // Both sets of chips use Material3 FilterChip — the selected chip gets a
-        // filled background; the unselected one has only an outlined border.
+        // ── Header row: settings gear icon (right-aligned) ───────────────────
+        // A single gear IconButton in the top-right corner replaces the scattered
+        // theme and language toggles that previously lived here. All preferences
+        // have been consolidated into the Settings page for a cleaner header.
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween, // push groups to each edge
-            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+            horizontalArrangement = Arrangement.End, // push the icon to the right edge
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            // ── Theme toggle (left) ───────────────────────────────────────────
-            // SingleChoiceSegmentedButtonRow groups related options into one visual
-            // unit: the selected segment gets a filled background, and unselected
-            // segments have no individual border — only the outer row border remains.
-            // This is clearer than separate FilterChips, which all show an outline.
-            val themeOptions   = listOf(AppTheme.LIGHT to "☀️", AppTheme.DARK to "🌙")
-            val themeLabelSize = rememberSharedAutoSizeState()
-            SingleChoiceSegmentedButtonRow {
-                themeOptions.forEachIndexed { index, (themeOption, label) ->
-                    SegmentedButton(
-                        shape    = SegmentedButtonDefaults.itemShape(index, themeOptions.size),
-                        selected = theme == themeOption,
-                        // Calling the callback even for the already-selected option
-                        // is safe and idiomatic: the caller simply sets the same value again.
-                        onClick  = { onThemeChange(themeOption) },
-                        // Suppress the default checkmark — the filled background already
-                        // communicates which option is selected.
-                        icon     = {}
-                    ) {
-                        AutoSizeText(
-                            text            = label,
-                            modifier        = Modifier.padding(horizontal = 1.dp),
-                            sharedSizeState = themeLabelSize
-                        )
-                    }
-                }
-            }
-
-            // ── Language toggle (right) ───────────────────────────────────────
-            val localeOptions   = listOf(AppLocale.EN to "🇬🇧", AppLocale.FR to "🇫🇷")
-            val localeLabelSize = rememberSharedAutoSizeState()
-            SingleChoiceSegmentedButtonRow {
-                localeOptions.forEachIndexed { index, (localeOption, label) ->
-                    SegmentedButton(
-                        shape    = SegmentedButtonDefaults.itemShape(index, localeOptions.size),
-                        selected = locale == localeOption,
-                        onClick  = { onLocaleChange(localeOption) },
-                        icon     = {}
-                    ) {
-                        AutoSizeText(
-                            text            = label,
-                            modifier        = Modifier.padding(horizontal = 1.dp),
-                            sharedSizeState = localeLabelSize
-                        )
-                    }
-                }
+            // IconButton provides the standard 48 dp touch target around the icon.
+            // contentDescription is read aloud by screen-readers (accessibility).
+            IconButton(onClick = onNavigateToSettings) {
+                Icon(
+                    imageVector        = Icons.Default.Settings,
+                    contentDescription = strings.settings,
+                    tint               = MaterialTheme.colorScheme.onSurface
+                )
             }
         }
 
@@ -327,40 +279,6 @@ fun LandingScreen(
             }
         }
 
-        // ── Feedback button ───────────────────────────────────────────────────
-        // Always at the very bottom of the scrollable column, below Past Games.
-        // Right-aligned so it doesn't compete with the centred "Start Game" CTA.
-        // TextButton (no fill, no border) keeps it subtle; the envelope icon makes
-        // its purpose instantly recognisable without reading the label.
-        // We use TextButton directly here (rather than AppTextButton) because we need
-        // to place an Icon alongside AutoSizeText inside the button content slot.
-        Spacer(modifier = Modifier.height(8.dp))
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End // push the button to the right edge
-        ) {
-            TextButton(
-                onClick = {
-                    // ACTION_SENDTO + "mailto:" URI opens the default email app.
-                    // Using SENDTO (rather than ACTION_SEND) ensures only email clients
-                    // respond to this intent — messaging apps are excluded.
-                    val intent = Intent(
-                        Intent.ACTION_SENDTO,
-                        Uri.parse("mailto:mandarinetech.dev@gmail.com")
-                    )
-                    context.startActivity(Intent.createChooser(intent, null))
-                }
-            ) {
-                // Icon on the left, label on the right, with 4 dp gap between them.
-                Icon(
-                    imageVector        = Icons.Default.Email,
-                    contentDescription = null, // label next to it already describes the action
-                    modifier           = Modifier.size(18.dp)
-                )
-                Spacer(modifier = Modifier.width(4.dp))
-                AutoSizeText(text = strings.feedbackButton)
-            }
-        }
     }   // end Column
     }   // end Box
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
@@ -19,9 +19,10 @@ import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
 import java.util.Locale
 
 // Represents which screen is currently shown in the app.
-// SETUP = the player name entry screen.
-// GAME  = the active game session.
-enum class Screen { SETUP, GAME }
+// SETUP    = the player name entry screen.
+// GAME     = the active game session.
+// SETTINGS = the settings page (theme, language, feedback).
+enum class Screen { SETUP, GAME, SETTINGS }
 
 // MainActivity is the entry point of every Android app.
 // It extends ComponentActivity, which is the base class for activities
@@ -110,11 +111,18 @@ class MainActivity : ComponentActivity() {
                                     gameViewModel.initGame(game.playerNames, game)
                                     currentScreen = Screen.GAME
                                 },
+                                // Navigate to the settings page when the gear icon is tapped.
+                                onNavigateToSettings = { currentScreen = Screen.SETTINGS }
+                            )
+                            Screen.SETTINGS -> SettingsScreen(
+                                modifier      = Modifier.padding(innerPadding),
+                                // Persist the user's theme choice and re-render the whole UI.
+                                onThemeChange = { gameViewModel.setTheme(it) },
                                 // Persist the user's language choice and trigger a recomposition
                                 // through the StateFlow → collectAsState → CompositionLocalProvider chain.
                                 onLocaleChange = { gameViewModel.setLocale(it) },
-                                // Persist the user's theme choice and re-render the whole UI.
-                                onThemeChange  = { gameViewModel.setTheme(it) }
+                                // Navigate back to the setup screen.
+                                onBack        = { currentScreen = Screen.SETUP }
                             )
                             Screen.GAME -> GameScreen(
                                 viewModel = gameViewModel,

--- a/app/src/main/java/fr/mandarine/tarotcounter/SettingsScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/SettingsScreen.kt
@@ -1,0 +1,203 @@
+package fr.mandarine.tarotcounter
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
+
+// SettingsScreen consolidates all user-preference controls in one place:
+//   - Theme toggle  (☀️ light / 🌙 dark)
+//   - Language toggle (🇬🇧 English / 🇫🇷 French)
+//   - Developer contact button
+//
+// It is a full-screen composable accessed from the gear icon on LandingScreen.
+//
+// onThemeChange:   called when the user taps a theme segment; persisted by the ViewModel.
+// onLocaleChange:  called when the user taps a language segment; persisted by the ViewModel.
+// onBack:          called when the user taps the back arrow; navigates to LandingScreen.
+@Composable
+fun SettingsScreen(
+    modifier: Modifier = Modifier,
+    onThemeChange: (AppTheme) -> Unit = {},
+    onLocaleChange: (AppLocale) -> Unit = {},
+    onBack: () -> Unit = {}
+) {
+    // Read the current locale and theme from the composition tree.
+    // These are provided by CompositionLocalProvider in MainActivity and automatically
+    // update when the user makes a selection — no extra state is needed here.
+    val locale  = LocalAppLocale.current
+    val theme   = LocalAppTheme.current
+    val strings = appStrings(locale)
+
+    // Context is needed to launch an external Intent (open the email client).
+    val context = LocalContext.current
+
+    // Box fills the whole screen and centers content horizontally so it looks good
+    // on both phones and wide tablets without stretching across the full width.
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter
+    ) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = MAX_CONTENT_WIDTH)
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top
+        ) {
+
+            // ── Back arrow + screen title ─────────────────────────────────────
+            // ScreenHeader renders a back arrow (← ) on the leading edge followed
+            // by the page title in headlineSmall style — the same pattern used by
+            // FinalScoreScreen and ScoreHistoryScreen.
+            ScreenHeader(title = strings.settingsTitle, onBack = onBack)
+
+            Spacer(modifier = Modifier.height(24.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ── Theme section ─────────────────────────────────────────────────
+            // A section label followed by a segmented button row (☀️ / 🌙).
+            // SingleChoiceSegmentedButtonRow makes it obvious that only one option
+            // can be selected at a time; the filled segment shows the current choice.
+            Text(
+                text     = strings.themeLabel,
+                style    = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            val themeOptions   = listOf(AppTheme.LIGHT to "☀️", AppTheme.DARK to "🌙")
+            val themeLabelSize = rememberSharedAutoSizeState(locale)
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth(0.5f)) {
+                themeOptions.forEachIndexed { index, (themeOption, label) ->
+                    SegmentedButton(
+                        shape    = SegmentedButtonDefaults.itemShape(index, themeOptions.size),
+                        selected = theme == themeOption,
+                        // Calling the callback even for the already-selected option is safe:
+                        // the ViewModel will simply persist the same value again.
+                        onClick  = { onThemeChange(themeOption) },
+                        // Suppress the default checkmark — the filled segment already signals
+                        // which option is selected.
+                        icon     = {}
+                    ) {
+                        AutoSizeText(
+                            text            = label,
+                            modifier        = Modifier.padding(horizontal = 1.dp),
+                            sharedSizeState = themeLabelSize
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ── Language section ──────────────────────────────────────────────
+            // Identical layout to the theme section: a label + a segmented button row.
+            Text(
+                text     = strings.languageLabel,
+                style    = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            val localeOptions   = listOf(AppLocale.EN to "🇬🇧", AppLocale.FR to "🇫🇷")
+            val localeLabelSize = rememberSharedAutoSizeState(locale)
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth(0.5f)) {
+                localeOptions.forEachIndexed { index, (localeOption, label) ->
+                    SegmentedButton(
+                        shape    = SegmentedButtonDefaults.itemShape(index, localeOptions.size),
+                        selected = locale == localeOption,
+                        onClick  = { onLocaleChange(localeOption) },
+                        icon     = {}
+                    ) {
+                        AutoSizeText(
+                            text            = label,
+                            modifier        = Modifier.padding(horizontal = 1.dp),
+                            sharedSizeState = localeLabelSize
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ── Feedback / contact section ────────────────────────────────────
+            // A TextButton (no fill, no border) keeps the action subtle. The
+            // envelope icon makes the purpose immediately clear without reading.
+            // Right-aligned so it doesn't compete with the centred toggles above.
+            //
+            // We use TextButton directly (rather than AppTextButton) because we need
+            // to place an Icon alongside AutoSizeText inside the button content slot.
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(
+                    onClick = {
+                        // ACTION_SENDTO + "mailto:" URI opens only email clients —
+                        // messaging apps are excluded by this intent filter.
+                        val intent = Intent(
+                            Intent.ACTION_SENDTO,
+                            Uri.parse("mailto:mandarinetech.dev@gmail.com")
+                        )
+                        context.startActivity(Intent.createChooser(intent, null))
+                    }
+                ) {
+                    // Icon on the left, label on the right, with 4 dp gap between them.
+                    Icon(
+                        imageVector        = Icons.Default.Email,
+                        contentDescription = null, // adjacent label already describes the action
+                        modifier           = Modifier.size(18.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    AutoSizeText(text = strings.feedbackButton)
+                }
+            }
+        }
+    }
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true)
+@Composable
+fun SettingsScreenPreview() {
+    TarotCounterTheme {
+        SettingsScreen()
+    }
+}

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,47 @@
+# Settings Screen
+
+## Overview
+
+The Settings screen consolidates all user-preference controls in one place, keeping the main
+setup screen (LandingScreen) uncluttered.
+
+It is reached by tapping the **gear icon** (⚙) in the top-right corner of the landing screen.
+A back arrow (←) returns the user to the landing screen.
+
+## Controls
+
+| Control | Values | Persisted via |
+|---------|--------|---------------|
+| Theme toggle | ☀️ Light / 🌙 Dark | `GameViewModel.setTheme()` → DataStore |
+| Language toggle | 🇬🇧 English / 🇫🇷 French | `GameViewModel.setLocale()` → DataStore |
+| Send Feedback | Opens default email client | Android Intent (mailto:) |
+
+Both the theme and language choices survive app restarts — they are stored with DataStore
+(see `docs/game-persistence.md`) and restored in `MainActivity` via `collectAsState()`.
+
+## Architecture
+
+`SettingsScreen` is a stateless composable that:
+
+1. Reads current values from `LocalAppLocale.current` and `LocalAppTheme.current`
+   (the same `CompositionLocal` providers used by every other screen).
+2. Calls `onThemeChange` / `onLocaleChange` lambdas when the user taps a segment —
+   `MainActivity` routes these callbacks to `GameViewModel`, which persists them.
+3. Calls `onBack` when the user taps the back arrow — `MainActivity` sets
+   `currentScreen = Screen.SETUP`.
+
+Navigation is handled by the same `Screen` enum that drives `LandingScreen` and `GameScreen`:
+
+```
+Screen.SETUP    ──(gear icon)──► Screen.SETTINGS
+Screen.SETTINGS ──(back arrow)──► Screen.SETUP
+```
+
+## File locations
+
+| File | Role |
+|------|------|
+| `app/src/main/…/SettingsScreen.kt` | Composable UI for the settings page |
+| `app/src/androidTest/…/SettingsScreenTest.kt` | UI tests for the settings page |
+| `app/src/main/…/AppStrings.kt` | `settings`, `settingsTitle`, `themeLabel`, `languageLabel` strings |
+| `app/src/main/…/MainActivity.kt` | `Screen.SETTINGS` enum value and navigation wiring |


### PR DESCRIPTION
## Summary

- Moves theme toggle (☀️/🌙), language toggle (🇬🇧/🇫🇷), and developer feedback button out of `LandingScreen` into a new dedicated `SettingsScreen`
- Replaces the cluttered header row on the landing screen with a single gear icon (⚙) in the top-right corner
- Adds `Screen.SETTINGS` to the navigation enum in `MainActivity`; the back arrow on `SettingsScreen` returns to `Screen.SETUP`

## Test plan

- [ ] New `SettingsScreenTest.kt`: back navigation, theme toggle callbacks, language toggle callbacks, feedback button display, section labels (EN + FR)
- [ ] Updated `LandingScreenTest.kt`: removed 9 tests for controls that moved to Settings; added 2 tests for the gear icon (displayed + tap callback)
- [ ] `./gradlew testDebugUnitTest` — passes
- [ ] `./gradlew pitest` — 81% mutation score (gate: 80%)
- [ ] `./gradlew lint` — no new warnings

Closes #120