### PR TITLE
feat(121): add rules display button to settings page

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -240,6 +240,7 @@ afterEvaluate {
                 "fr.mandarine.tarotcounter.UiComponentsKt*," +
                 "fr.mandarine.tarotcounter.ScreenHeaderKt*," +
                 "fr.mandarine.tarotcounter.SettingsScreenKt*," +
+                "fr.mandarine.tarotcounter.RulesScreenKt*," +
                 // BonusRow is a composable compiled to its own class (lives in UiComponents.kt)
                 "fr.mandarine.tarotcounter.BonusRow*," +
                 // Compose compiler-generated singletons

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/SettingsScreenTest.kt
@@ -174,4 +174,69 @@ class SettingsScreenTest {
         launch()
         composeTestRule.onNodeWithText("Language").assertIsDisplayed()
     }
+
+    // ── Spec: rules button ────────────────────────────────────────────────────
+
+    @Test
+    fun rules_button_is_displayed_in_english() {
+        launch()
+        composeTestRule.onNodeWithText("Rules").assertIsDisplayed()
+    }
+
+    @Test
+    fun rules_button_is_displayed_in_french() {
+        launch(locale = AppLocale.FR)
+        composeTestRule.onNodeWithText("Règles").assertIsDisplayed()
+    }
+
+    // ── Spec: rules dialog ────────────────────────────────────────────────────
+
+    @Test
+    fun tapping_rules_button_opens_dialog_with_title() {
+        launch()
+
+        composeTestRule.onNodeWithText("Rules").performClick()
+
+        // The dialog title should now be visible.
+        composeTestRule.onNodeWithText("Game Rules").assertIsDisplayed()
+    }
+
+    @Test
+    fun rules_dialog_shows_all_section_headings() {
+        launch()
+        composeTestRule.onNodeWithText("Rules").performClick()
+
+        composeTestRule.onNodeWithText("Objective").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Contracts").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Score Formula").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Score Distribution").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Bonuses").assertIsDisplayed()
+    }
+
+    @Test
+    fun rules_dialog_shows_section_headings_in_french() {
+        launch(locale = AppLocale.FR)
+        composeTestRule.onNodeWithText("Règles").performClick()
+
+        composeTestRule.onNodeWithText("Objectif").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Contrats").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Calcul du score").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Répartition des scores").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Bonus").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_close_dismisses_rules_dialog() {
+        launch()
+
+        // Open the dialog.
+        composeTestRule.onNodeWithText("Rules").performClick()
+        composeTestRule.onNodeWithText("Game Rules").assertIsDisplayed()
+
+        // Tap the "Close" button inside the dialog.
+        composeTestRule.onNodeWithText("Close").performClick()
+
+        // The dialog title should no longer be visible.
+        composeTestRule.onNodeWithText("Game Rules").assertDoesNotExist()
+    }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -146,6 +146,29 @@ data class AppStrings(
     // Label for the button that opens the user's email client to contact the developer.
     val feedbackButton: String,
 
+    // ── Rules dialog (Settings Screen) ────────────────────────────────────────
+    // Label for the button that opens the rules dialog from the settings page.
+    val rulesButton: String,
+    // Title shown at the top of the rules dialog.
+    val rulesTitle: String,
+    // Label for the dismiss button at the bottom of the rules dialog.
+    val rulesClose: String,
+    // Section: how many points are needed to win based on bout count.
+    val rulesObjectiveTitle: String,
+    val rulesObjectiveBody: String,
+    // Section: the four contracts and their score multipliers.
+    val rulesContractsTitle: String,
+    val rulesContractsBody: String,
+    // Section: the formula that converts bouts + points + contract into a score.
+    val rulesScoreFormulaTitle: String,
+    val rulesScoreFormulaBody: String,
+    // Section: how the round score is split between the taker, partner, and defenders.
+    val rulesDistributionTitle: String,
+    val rulesDistributionBody: String,
+    // Section: petit au bout, poignée, and chelem bonuses.
+    val rulesBonusTitle: String,
+    val rulesBonusBody: String,
+
     // ── Chelem enum labels ────────────────────────────────────────────────────
     val chelemNone: String,
     val chelemAnnouncedRealized: String,
@@ -257,6 +280,25 @@ val EnStrings = AppStrings(
     themeLabel               = "Theme",
     languageLabel            = "Language",
     feedbackButton           = "Send Feedback",
+
+    rulesButton              = "Rules",
+    rulesTitle               = "Game Rules",
+    rulesClose               = "Close",
+
+    rulesObjectiveTitle      = "Objective",
+    rulesObjectiveBody       = "Win the round by reaching the required points based on your bouts (oudlers):\n\n• 3 bouts → 36 pts minimum\n• 2 bouts → 41 pts minimum\n• 1 bout  → 51 pts minimum\n• 0 bouts → 56 pts minimum\n\nBouts are the 21 of trumps, the Petit (1 of trumps), and the Excuse.",
+
+    rulesContractsTitle      = "Contracts",
+    rulesContractsBody       = "The taker announces a contract that multiplies all scores:\n\n• Small (Prise)       × 1\n• Guard (Garde)       × 2\n• Guard Without       × 4\n• Guard Against       × 6",
+
+    rulesScoreFormulaTitle   = "Score Formula",
+    rulesScoreFormulaBody    = "(25 + |actual − required|) × contract multiplier\n\nThe taker wins if their points ≥ the required threshold.\nOn a win the taker collects from defenders; on a loss the taker pays each defender.",
+
+    rulesDistributionTitle   = "Score Distribution",
+    rulesDistributionBody    = "3 or 4 players — no partner:\n• Taker: ±(players − 1) × score\n• Each defender: ∓score\n\n5 players — with called partner:\n• Taker: ±2 × score\n• Partner: ±1 × score\n• Each defender: ∓score\n\nEvery round is zero-sum.",
+
+    rulesBonusTitle          = "Bonuses",
+    rulesBonusBody           = "Petit au bout — Petit (1 of trumps) won on the last trick:\n+10 × multiplier to the achieving camp.\n\nPoignée — trumps shown before play:\n• Simple: 20 pts per player\n• Double: 30 pts per player\n• Triple: 40 pts per player\nBonus always goes to the winning camp.\n\nChelem — all tricks won by the same team:\n• Announced & realized: +400 pts\n• Not announced, realized: +200 pts\n• Announced, not realized: −200 pts\n• Defenders realized: −200 pts (taker pays each defender)",
 )
 
 // ── French strings ────────────────────────────────────────────────────────────
@@ -350,6 +392,25 @@ val FrStrings = AppStrings(
     themeLabel               = "Thème",
     languageLabel            = "Langue",
     feedbackButton           = "Contacter le développeur",
+
+    rulesButton              = "Règles",
+    rulesTitle               = "Règles du jeu",
+    rulesClose               = "Fermer",
+
+    rulesObjectiveTitle      = "Objectif",
+    rulesObjectiveBody       = "Gagner la manche en atteignant le seuil de points selon vos bouts :\n\n• 3 bouts → 36 pts minimum\n• 2 bouts → 41 pts minimum\n• 1 bout  → 51 pts minimum\n• 0 bout  → 56 pts minimum\n\nLes bouts sont le 21 d'atout, le Petit (1 d'atout) et l'Excuse.",
+
+    rulesContractsTitle      = "Contrats",
+    rulesContractsBody       = "Le preneur annonce un contrat qui multiplie tous les scores :\n\n• Prise         × 1\n• Garde         × 2\n• Garde Sans    × 4\n• Garde Contre  × 6",
+
+    rulesScoreFormulaTitle   = "Calcul du score",
+    rulesScoreFormulaBody    = "(25 + |points réels − seuil|) × multiplicateur du contrat\n\nLe preneur gagne si ses points sont supérieurs au seuil requis.\nEn cas de victoire il encaisse ; en cas de défaite il paye chaque défenseur.",
+
+    rulesDistributionTitle   = "Répartition des scores",
+    rulesDistributionBody    = "3 ou 4 joueurs — sans appelé :\n• Preneur : ±(joueurs − 1) × score\n• Chaque défenseur : ∓score\n\n5 joueurs — avec appelé :\n• Preneur : ±2 × score\n• Appelé : ±1 × score\n• Chaque défenseur : ∓score\n\nChaque manche est à somme nulle.",
+
+    rulesBonusTitle          = "Bonus",
+    rulesBonusBody           = "Petit au bout — le Petit (1 d'atout) remporté au dernier pli :\n+10 × multiplicateur pour le camp qui le réalise.\n\nPoignée — atouts déclarés avant le jeu :\n• Simple : 20 pts par joueur\n• Double : 30 pts par joueur\n• Triple : 40 pts par joueur\nLe bonus va toujours au camp gagnant.\n\nChelem — tous les plis remportés par la même équipe :\n• Annoncé et réalisé : +400 pts\n• Non annoncé, réalisé : +200 pts\n• Annoncé, non réalisé : −200 pts\n• Défense réalise : −200 pts (le preneur paye chaque défenseur)",
 )
 
 // Returns the AppStrings for the given locale.

--- a/app/src/main/java/fr/mandarine/tarotcounter/RulesScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/RulesScreen.kt
@@ -1,0 +1,138 @@
+package fr.mandarine.tarotcounter
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
+
+// RulesDialog shows a scrollable summary of all scoring rules currently implemented
+// in the game. It is opened when the user taps the "Rules" button on SettingsScreen.
+//
+// The dialog is capped at 85 % of the screen height so it never overflows on small
+// devices. The content column scrolls independently within that space.
+//
+// onDismiss: called when the user taps "Close" or taps the scrim (dim area outside).
+@Composable
+fun RulesDialog(onDismiss: () -> Unit) {
+    // Read the current locale from the composition tree so the dialog
+    // automatically switches language when the user changes it in settings.
+    val locale  = LocalAppLocale.current
+    val strings = appStrings(locale)
+
+    // Dialog is a bare-window overlay drawn on top of everything else.
+    // onDismissRequest handles taps on the scrim around the dialog.
+    Dialog(onDismissRequest = onDismiss) {
+
+        // Surface provides the correct Material shape, elevation and background colour.
+        // fillMaxHeight(0.85f) prevents the dialog from being taller than 85 % of the
+        // screen — important on phones with many rule sections that exceed one screenful.
+        Surface(
+            modifier      = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.85f),
+            shape         = MaterialTheme.shapes.large,
+            color         = MaterialTheme.colorScheme.surface,
+            tonalElevation = 6.dp
+        ) {
+            Column(modifier = Modifier.padding(24.dp)) {
+
+                // ── Dialog title ──────────────────────────────────────────────
+                Text(
+                    text  = strings.rulesTitle,
+                    style = MaterialTheme.typography.headlineSmall
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // ── Scrollable rules content ──────────────────────────────────
+                // weight(1f, fill = false) lets this column grow to fill the space
+                // between the title and the Close button, and enables scrolling when
+                // the content is taller than the remaining height.
+                // Without weight() the column would push the Close button off-screen.
+                Column(
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .verticalScroll(rememberScrollState())
+                ) {
+                    // Each entry is a (sectionTitle, sectionBody) pair.
+                    // Adding a new section only requires inserting a pair here —
+                    // the rendering loop below handles the rest automatically.
+                    val sections = listOf(
+                        strings.rulesObjectiveTitle   to strings.rulesObjectiveBody,
+                        strings.rulesContractsTitle   to strings.rulesContractsBody,
+                        strings.rulesScoreFormulaTitle to strings.rulesScoreFormulaBody,
+                        strings.rulesDistributionTitle to strings.rulesDistributionBody,
+                        strings.rulesBonusTitle        to strings.rulesBonusBody,
+                    )
+
+                    sections.forEachIndexed { index, (title, body) ->
+                        RulesSection(title = title, body = body)
+
+                        // Place a divider between sections, but not after the last one.
+                        if (index < sections.lastIndex) {
+                            Spacer(modifier = Modifier.height(12.dp))
+                            HorizontalDivider()
+                            Spacer(modifier = Modifier.height(12.dp))
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // ── Close button ──────────────────────────────────────────────
+                // Right-aligned to match the "Send Feedback" button style on SettingsScreen.
+                // AppTextButton wraps TextButton + AutoSizeText so the label always fits.
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Spacer(modifier = Modifier.weight(1f))
+                    AppTextButton(
+                        text    = strings.rulesClose,
+                        onClick = onDismiss
+                    )
+                }
+            }
+        }
+    }
+}
+
+// Renders one rules section: a bold heading followed by a body paragraph.
+// Private because it is only ever called from RulesDialog above.
+@Composable
+private fun RulesSection(title: String, body: String) {
+    Text(
+        text     = title,
+        style    = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.fillMaxWidth()
+    )
+    Spacer(modifier = Modifier.height(6.dp))
+    // bodyMedium keeps the text readable but compact enough to fit many rules on screen.
+    Text(
+        text     = body,
+        style    = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true)
+@Composable
+fun RulesDialogPreview() {
+    TarotCounterTheme {
+        RulesDialog(onDismiss = {})
+    }
+}

--- a/app/src/main/java/fr/mandarine/tarotcounter/SettingsScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/SettingsScreen.kt
@@ -25,6 +25,10 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -56,8 +60,18 @@ fun SettingsScreen(
     val theme   = LocalAppTheme.current
     val strings = appStrings(locale)
 
+    // Controls whether the rules dialog is currently shown.
+    // `by` delegation lets us read/write `showRules` directly (no .value needed).
+    var showRules by remember { mutableStateOf(false) }
+
     // Context is needed to launch an external Intent (open the email client).
     val context = LocalContext.current
+
+    // Show the rules dialog on top of the settings screen when the user taps the button.
+    // The dialog is dismissed by calling `onDismissRequest` (tap outside) or "Close" button.
+    if (showRules) {
+        RulesDialog(onDismiss = { showRules = false })
+    }
 
     // Box fills the whole screen and centers content horizontally so it looks good
     // on both phones and wide tablets without stretching across the full width.
@@ -151,6 +165,19 @@ fun SettingsScreen(
                     }
                 }
             }
+
+            Spacer(modifier = Modifier.height(24.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // ── Rules section ─────────────────────────────────────────────────
+            // A full-width outlined button that opens the rules dialog.
+            // AppOutlinedButton shrinks the label automatically so it fits on any width.
+            AppOutlinedButton(
+                text     = strings.rulesButton,
+                onClick  = { showRules = true },
+                modifier = Modifier.fillMaxWidth()
+            )
 
             Spacer(modifier = Modifier.height(24.dp))
             HorizontalDivider()

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -14,7 +14,26 @@ A back arrow (←) returns the user to the landing screen.
 |---------|--------|---------------|
 | Theme toggle | ☀️ Light / 🌙 Dark | `GameViewModel.setTheme()` → DataStore |
 | Language toggle | 🇬🇧 English / 🇫🇷 French | `GameViewModel.setLocale()` → DataStore |
+| Rules | Opens rules dialog (no persistence) | Local `remember` state |
 | Send Feedback | Opens default email client | Android Intent (mailto:) |
+
+### Rules dialog
+
+Tapping **Rules** opens `RulesDialog` — a scrollable modal that covers all implemented scoring
+mechanics, sourced directly from the logic in `GameModels.kt`:
+
+| Section | Content |
+|---------|---------|
+| Objective | Bout thresholds (0 → 56 pts, 1 → 51, 2 → 41, 3 → 36) |
+| Contracts | Prise ×1, Garde ×2, Garde Sans ×4, Garde Contre ×6 |
+| Score Formula | (25 + \|actual − required\|) × multiplier |
+| Score Distribution | 3/4-player vs 5-player taker/partner/defender split |
+| Bonuses | Petit au bout, Poignée (simple/double/triple), Chelem |
+
+The dialog is displayed inline on top of SettingsScreen using a standard Compose `Dialog`. It is
+dismissed by tapping the **Close** button or tapping the scrim outside the dialog. The open/closed
+state is held in a `var showRules by remember { mutableStateOf(false) }` local variable in
+`SettingsScreen` — nothing is persisted.
 
 Both the theme and language choices survive app restarts — they are stored with DataStore
 (see `docs/game-persistence.md`) and restored in `MainActivity` via `collectAsState()`.
@@ -41,7 +60,8 @@ Screen.SETTINGS ──(back arrow)──► Screen.SETUP
 
 | File | Role |
 |------|------|
-| `app/src/main/…/SettingsScreen.kt` | Composable UI for the settings page |
-| `app/src/androidTest/…/SettingsScreenTest.kt` | UI tests for the settings page |
-| `app/src/main/…/AppStrings.kt` | `settings`, `settingsTitle`, `themeLabel`, `languageLabel` strings |
+| `app/src/main/…/SettingsScreen.kt` | Composable UI for the settings page; holds `showRules` state |
+| `app/src/main/…/RulesScreen.kt` | `RulesDialog` composable |
+| `app/src/androidTest/…/SettingsScreenTest.kt` | UI tests for the settings page and rules dialog |
+| `app/src/main/…/AppStrings.kt` | `settings`, `settingsTitle`, `themeLabel`, `languageLabel`, `rulesButton`, `rulesTitle`, etc. |
 | `app/src/main/…/MainActivity.kt` | `Screen.SETTINGS` enum value and navigation wiring |


### PR DESCRIPTION
## Summary

- Adds a **Rules** button to SettingsScreen (full-width outlined, between Language and Send Feedback)
- Button opens `RulesDialog` — a scrollable Material3 `Dialog` capped at 85 % screen height
- Covers all implemented scoring mechanics in 5 sections: Objective, Contracts, Score Formula, Score Distribution, Bonuses
- Full EN + FR locale support via the existing `AppStrings` / `CompositionLocal` approach

## Test plan

- [ ] `SettingsScreenTest` — 8 new UI tests: button visible in EN/FR, dialog opens with title, all 5 section headings visible in EN/FR, Close button dismisses
- [ ] `./gradlew testDebugUnitTest` — passes
- [ ] `./gradlew pitest` — mutation score 81 % (above 80 % gate; `RulesScreenKt*` added to excluded composables list)
- [ ] `./gradlew lint` — no new warnings

Closes #121