### PR TITLE
feat(128): add first-dealer selection to setup screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Android app for tracking scores in **French Tarot**, a classic French trick-t
 
 TarotCounter guides players through a game round by round:
 
-1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap the **⚙ gear icon** (top-right) to open the Settings page
+1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; choose the **first dealer** (random or pick a specific player); a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap the **⚙ gear icon** (top-right) to open the Settings page
 2. **Attacker selection + contract** — tap the player who won the bidding to set them as the **attacker** (any player can bid, not just the dealer); then pick their contract; the dealer label shows who is distributing the cards this round; a persistent **bottom action bar** always shows **End Game** (left) and **Skip round** (right) for quick access
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
 4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first; each history row shows a colored **●** indicator (green = won, red = lost, grey = skipped) for at-a-glance scanning

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -14,6 +15,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,9 +42,13 @@ class LandingScreenTest {
     /**
      * Launches LandingScreen inside our app theme (same as production).
      * [onNavigateToSettings] captures whether the settings gear was tapped.
+     *
+     * The [onStartGame] lambda now receives both the raw name list **and** the chosen
+     * dealer index (null = random). Existing tests that only care about names use the
+     * default no-op `{ _, _ -> }`.
      */
     private fun launch(
-        onStartGame: (List<String>) -> Unit = {},
+        onStartGame: (List<String>, Int?) -> Unit = { _, _ -> },
         onNavigateToSettings: () -> Unit = {}
     ) {
         composeTestRule.setContent {
@@ -189,7 +195,7 @@ class LandingScreenTest {
     @Test
     fun start_game_callback_receives_three_names_by_default() {
         var capturedNames: List<String>? = null
-        launch(onStartGame = { capturedNames = it })
+        launch(onStartGame = { names, _ -> capturedNames = names })
 
         composeTestRule.onNodeWithText("Start Game").performClick()
 
@@ -201,7 +207,7 @@ class LandingScreenTest {
     @Test
     fun start_game_callback_receives_five_names_when_chip_5_selected() {
         var capturedNames: List<String>? = null
-        launch(onStartGame = { capturedNames = it })
+        launch(onStartGame = { names, _ -> capturedNames = names })
 
         composeTestRule.onNodeWithText("5").performClick()
         composeTestRule.onNodeWithText("Start Game").performClick()
@@ -329,6 +335,74 @@ class LandingScreenTest {
         // The winner result text should appear (e.g. "Alice +150") inside the card.
         // We use a substring check via containsText to stay locale-agnostic.
         composeTestRule.onNodeWithText("Alice", substring = true).assertIsDisplayed()
+    }
+
+    // ── Spec: dealer selection section (issue #128) ───────────────────────────
+
+    @Test
+    fun dealer_selection_section_heading_is_displayed() {
+        launch()
+        composeTestRule.onNodeWithText("First Dealer").assertIsDisplayed()
+    }
+
+    @Test
+    fun random_option_is_displayed_and_selected_by_default() {
+        launch()
+        // The "Random" segment must be visible when the screen opens.
+        composeTestRule.onNodeWithText("Random").assertIsDisplayed()
+    }
+
+    @Test
+    fun choose_option_is_displayed() {
+        launch()
+        composeTestRule.onNodeWithText("Choose").assertIsDisplayed()
+    }
+
+    @Test
+    fun start_game_callback_receives_null_dealer_index_when_random_is_selected() {
+        // Default mode is Random — the dealer index passed to onStartGame must be null.
+        var capturedDealerIndex: Int? = -1  // sentinel: will be overwritten by the callback
+        launch(onStartGame = { _, dealerIndex -> capturedDealerIndex = dealerIndex })
+
+        composeTestRule.onNodeWithText("Start Game").performClick()
+
+        assertNull(
+            "Dealer index must be null when Random mode is selected",
+            capturedDealerIndex
+        )
+    }
+
+    @Test
+    fun start_game_callback_receives_non_null_dealer_index_when_choose_is_selected() {
+        // When the user picks "Choose", the callback must receive a non-null index.
+        var capturedDealerIndex: Int? = -1
+        launch(onStartGame = { _, dealerIndex -> capturedDealerIndex = dealerIndex })
+
+        composeTestRule.onNodeWithText("Choose").performClick()
+        composeTestRule.onNodeWithText("Start Game").performClick()
+
+        assertNotNull(
+            "Dealer index must be non-null when Choose mode is selected",
+            capturedDealerIndex
+        )
+    }
+
+    @Test
+    fun start_game_callback_receives_correct_index_when_second_player_chosen_as_dealer() {
+        // Tap "Choose", then tap Player 2. The callback must report index 1.
+        var capturedDealerIndex: Int? = -1
+        launch(onStartGame = { _, dealerIndex -> capturedDealerIndex = dealerIndex })
+
+        composeTestRule.onNodeWithText("Choose").performClick()
+        // There are multiple "Player 2" nodes (name field label + dealer chip).
+        // useUnmergedTree = false is fine here; the first match is the dealer chip.
+        composeTestRule.onAllNodesWithText("Player 2")[0].performClick()
+        composeTestRule.onNodeWithText("Start Game").performClick()
+
+        assertEquals(
+            "Index 1 expected when Player 2 (index 1) is chosen as dealer",
+            1, capturedDealerIndex
+        )
     }
 
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -18,6 +18,12 @@ data class AppStrings(
     val playerFallback: (index: Int) -> String,
     val nameAlreadyUsed: String,
     val startGame: String,
+    // Section header for the first-dealer selection row on the setup screen.
+    val dealerSelectionLabel: String,
+    // Label for the "random dealer" option in the dealer selection toggle.
+    val randomDealer: String,
+    // Label for the "choose a specific player" option in the dealer selection toggle.
+    val chooseDealer: String,
     val pastGames: String,
     // Title of the "resume" card shown when an unfinished game exists.
     val resumeGameTitle: String,
@@ -196,6 +202,9 @@ val EnStrings = AppStrings(
     playerFallback        = { i -> "Player $i" },
     nameAlreadyUsed       = "Name already used",
     startGame             = "Start Game",
+    dealerSelectionLabel  = "First Dealer",
+    randomDealer          = "Random",
+    chooseDealer          = "Choose",
     pastGames             = "Past Games",
     resumeGameTitle       = "Resume Game",
     roundsPlayed          = { n -> if (n == 1) "1 round played" else "$n rounds played" },
@@ -310,6 +319,9 @@ val FrStrings = AppStrings(
     playerFallback        = { i -> "Joueur $i" },
     nameAlreadyUsed       = "Nom déjà utilisé",
     startGame             = "Démarrer",
+    dealerSelectionLabel  = "Premier distributeur",
+    randomDealer          = "Aléatoire",
+    chooseDealer          = "Choisir",
     pastGames             = "Parties précédentes",
     resumeGameTitle       = "Partie en cours",
     roundsPlayed          = { n -> if (n == 1) "1 manche jouée" else "$n manches jouées" },

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -319,7 +319,7 @@ val FrStrings = AppStrings(
     playerFallback        = { i -> "Joueur $i" },
     nameAlreadyUsed       = "Nom déjà utilisé",
     startGame             = "Démarrer",
-    dealerSelectionLabel  = "Premier distributeur",
+    dealerSelectionLabel  = "Premier donneur",
     randomDealer          = "Aléatoire",
     chooseDealer          = "Choisir",
     pastGames             = "Parties précédentes",
@@ -333,7 +333,7 @@ val FrStrings = AppStrings(
     roundCount            = { n -> if (n == 1) "1 manche" else "$n manches" },
 
     roundHeader           = { n -> "Manche $n" },
-    dealerLabel           = { dealer -> "Distributeur : $dealer" },
+    dealerLabel           = { dealer -> "Donneur : $dealer" },
     attackerLabel         = "Preneur",
     chooseContract        = { taker -> "$taker — choisissez un contrat :" },
     skipRound             = "Passer",

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameViewModel.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameViewModel.kt
@@ -127,14 +127,26 @@ class GameViewModel internal constructor(
 
     // Initializes (or restores) a game session.
     //
-    // displayNames : resolved player names — blank entries must have been replaced
-    //               by the caller (e.g. "Player 1") before passing them in.
-    // inProgressGame : non-null when resuming a saved game; null for a fresh start.
-    fun initGame(displayNames: List<String>, inProgressGame: InProgressGame?) {
+    // displayNames         : resolved player names — blank entries must have been replaced
+    //                        by the caller (e.g. "Player 1") before passing them in.
+    // inProgressGame       : non-null when resuming a saved game; null for a fresh start.
+    // startingIndexOverride: optional index of the player chosen to deal first (0-based).
+    //                        Only used for a fresh start (inProgressGame == null).
+    //                        Null means the first dealer is picked randomly (legacy behaviour).
+    fun initGame(
+        displayNames: List<String>,
+        inProgressGame: InProgressGame?,
+        startingIndexOverride: Int? = null
+    ) {
         _displayNames  = displayNames
         _gameId        = inProgressGame?.gameId?.ifBlank { UUID.randomUUID().toString() }
                             ?: UUID.randomUUID().toString()
-        _startingIndex = inProgressGame?.startingIndex ?: displayNames.indices.random()
+        // Priority: restored index > explicit choice > random.
+        // `inProgressGame?.startingIndex` is non-null when resuming, so the override
+        // is correctly ignored in that case.
+        _startingIndex = inProgressGame?.startingIndex
+            ?: startingIndexOverride
+            ?: displayNames.indices.random()
         currentRound   = inProgressGame?.currentRound ?: 1
         roundHistory.clear()
         inProgressGame?.rounds?.let { roundHistory.addAll(it) }

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -54,7 +55,10 @@ import java.util.Locale as JavaLocale
 //   - a "Resume Game" card (if there is an unfinished game saved from a previous session)
 //   - a "Past Games" list at the bottom (if any games have been completed)
 //
-// onStartGame:          lambda called when the user presses "Start Game" with a list of names.
+// onStartGame:          lambda called when the user presses "Start Game".
+//                         names      : raw names entered by the user (blank = use fallback).
+//                         dealerIndex: index of the chosen first dealer in `names`, or null
+//                                      to let the app pick a random dealer.
 // onResumeGame:         lambda called when the user taps "Resume" — passes the saved state back
 //                       to MainActivity so GameScreen can be initialized from it.
 // onNavigateToSettings: lambda called when the user taps the gear icon to open the Settings page.
@@ -65,7 +69,7 @@ fun LandingScreen(
     modifier: Modifier = Modifier,
     inProgressGame: InProgressGame? = null,
     pastGames: List<SavedGame> = emptyList(),
-    onStartGame: (List<String>) -> Unit = {},
+    onStartGame: (names: List<String>, dealerIndex: Int?) -> Unit = { _, _ -> },
     onResumeGame: (InProgressGame) -> Unit = {},
     onNavigateToSettings: () -> Unit = {}
 ) {
@@ -80,6 +84,16 @@ fun LandingScreen(
     // `mutableStateListOf` creates an observable list: any change triggers a UI redraw.
     // Initialized with 3 empty strings matching the default player count.
     val playerNames = remember { mutableStateListOf("", "", "") }
+
+    // Dealer selection state — declared early so the player-count onClick handlers can
+    // reference them when resetting the chosen dealer after a player-count change.
+    //
+    // `useRandomDealer` toggles between random (true, default) and manual (false).
+    // `selectedDealerIndex` is the index into resolvedNames of the manually chosen dealer;
+    //   defaults to 0 (first player) so there is always a valid selection when switching
+    //   to manual mode.
+    var useRandomDealer by remember { mutableStateOf(true) }
+    var selectedDealerIndex by remember { mutableIntStateOf(0) }
 
     // Box fills the whole screen and centers its child horizontally.
     // This ensures the content Column is centered on wide screens (e.g. tablets in landscape)
@@ -186,6 +200,10 @@ fun LandingScreen(
                         // If smaller, drop the extra entries from the end.
                         while (playerNames.size < n) playerNames.add("")
                         while (playerNames.size > n) playerNames.removeAt(playerNames.lastIndex)
+                        // Reset the manual dealer choice so it is never out of range
+                        // after the player list shrinks (e.g. picked index 4 with 5
+                        // players, then switched back to 3).
+                        selectedDealerIndex = 0
                     },
                     icon = {} // suppress the default checkmark icon
                 ) {
@@ -244,12 +262,85 @@ fun LandingScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
+        // ── Dealer selection ──────────────────────────────────────────────────
+        // By default the app picks a random first dealer (matching the original
+        // behaviour). The user can switch to "Choose" and pick a specific player.
+
+        Text(
+            text  = strings.dealerSelectionLabel,
+            style = MaterialTheme.typography.titleMedium
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // A two-segment toggle: "Random" (left) vs "Choose" (right).
+        // `rememberSharedAutoSizeState(locale)` resets the shared font size when
+        // the language changes so both labels are measured fresh.
+        val dealerModeSize = rememberSharedAutoSizeState(locale)
+        SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth(0.6f)) {
+            SegmentedButton(
+                shape    = SegmentedButtonDefaults.itemShape(0, 2),
+                selected = useRandomDealer,
+                onClick  = { useRandomDealer = true },
+                icon     = {} // suppress the default checkmark
+            ) {
+                AutoSizeText(
+                    text            = strings.randomDealer,
+                    modifier        = Modifier.padding(horizontal = 1.dp),
+                    sharedSizeState = dealerModeSize
+                )
+            }
+            SegmentedButton(
+                shape    = SegmentedButtonDefaults.itemShape(1, 2),
+                selected = !useRandomDealer,
+                onClick  = { useRandomDealer = false },
+                icon     = {}
+            ) {
+                AutoSizeText(
+                    text            = strings.chooseDealer,
+                    modifier        = Modifier.padding(horizontal = 1.dp),
+                    sharedSizeState = dealerModeSize
+                )
+            }
+        }
+
+        // When "Choose" is selected, show one segment per player so the user can
+        // tap the name of the person who will deal first.
+        if (!useRandomDealer) {
+            Spacer(modifier = Modifier.height(12.dp))
+            // Shared state ensures all player-name labels display at the same size —
+            // the smallest size needed to fit the longest name.
+            val dealerNameSize = rememberSharedAutoSizeState(locale)
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+                resolvedNames.forEachIndexed { index, name ->
+                    SegmentedButton(
+                        shape    = SegmentedButtonDefaults.itemShape(index, resolvedNames.size),
+                        selected = selectedDealerIndex == index,
+                        onClick  = { selectedDealerIndex = index },
+                        icon     = {}
+                    ) {
+                        AutoSizeText(
+                            text            = name,
+                            modifier        = Modifier.padding(horizontal = 1.dp),
+                            sharedSizeState = dealerNameSize
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
         // "Start Game" button placed BELOW the name fields so the visual flow naturally
         // guides the user: enter names first, then press Start.
         // `enabled = !hasDuplicates` prevents starting a game when names clash.
         AppButton(
             text     = strings.startGame,
-            onClick  = { onStartGame(playerNames.toList()) },
+            // Pass `null` for random mode or the chosen index for manual mode.
+            onClick  = {
+                val dealerIndex = if (useRandomDealer) null else selectedDealerIndex
+                onStartGame(playerNames.toList(), dealerIndex)
+            },
             enabled  = !hasDuplicates,
             modifier = Modifier.fillMaxWidth(0.8f)
         )

--- a/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/MainActivity.kt
@@ -96,12 +96,18 @@ class MainActivity : ComponentActivity() {
                                 inProgressGame = inProgressGame,
                                 // Start a fresh game: resolve display names (blank entries become
                                 // "Player N" / "Joueur N"), then initialize the ViewModel session.
-                                onStartGame = { rawNames ->
+                                // `dealerIndex` is the user's chosen first-dealer index, or null
+                                // to let the app pick randomly (the default behaviour).
+                                onStartGame = { rawNames, dealerIndex ->
                                     val appStrings = appStrings(currentLocale)
                                     val resolvedNames = rawNames.mapIndexed { i, name ->
                                         name.ifBlank { appStrings.playerFallback(i + 1) }
                                     }
-                                    gameViewModel.initGame(resolvedNames, inProgressGame = null)
+                                    gameViewModel.initGame(
+                                        displayNames          = resolvedNames,
+                                        inProgressGame        = null,
+                                        startingIndexOverride = dealerIndex
+                                    )
                                     gameViewModel.clearInProgressGame()
                                     currentScreen = Screen.GAME
                                 },

--- a/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
+++ b/app/src/test/java/fr/mandarine/tarotcounter/GameViewModelTest.kt
@@ -721,6 +721,60 @@ class GameViewModelTest {
         assertEquals("Alice", vm.currentDealer)
     }
 
+    // ── initGame — startingIndexOverride ─────────────────────────────────────
+
+    @Test
+    fun `initGame with startingIndexOverride uses that index for a fresh game`() {
+        // When the user manually picks a dealer on the setup screen, the chosen index
+        // must be used as the starting index for the new game.
+        val players = listOf("Alice", "Bob", "Charlie")
+        val vm = GameViewModel(Application(), FakeGameStorage())
+
+        vm.initGame(players, inProgressGame = null, startingIndexOverride = 2)
+
+        assertEquals(
+            "startingIndexOverride should set the starting index when no inProgressGame is given",
+            2, vm.startingIndex
+        )
+    }
+
+    @Test
+    fun `initGame startingIndexOverride is ignored when inProgressGame is provided`() {
+        // When resuming a saved game the stored index takes precedence; the UI cannot
+        // override it because the dealer rotation must continue from where it left off.
+        val players = listOf("Alice", "Bob", "Charlie")
+        val vm = GameViewModel(Application(), FakeGameStorage())
+        val saved = InProgressGame(
+            gameId        = "g1",
+            playerNames   = players,
+            currentRound  = 3,
+            startingIndex = 1,   // saved: Bob (index 1) was the first dealer
+            rounds        = emptyList()
+        )
+
+        // Pass override = 2 (Charlie), but it must be ignored in favour of the saved 1 (Bob).
+        vm.initGame(players, saved, startingIndexOverride = 2)
+
+        assertEquals(
+            "Saved startingIndex must take precedence over startingIndexOverride",
+            1, vm.startingIndex
+        )
+    }
+
+    @Test
+    fun `initGame with null startingIndexOverride picks a random index`() {
+        // Without an override, any valid index in 0..players.lastIndex is acceptable.
+        val players = listOf("Alice", "Bob", "Charlie")
+        val vm = GameViewModel(Application(), FakeGameStorage())
+
+        vm.initGame(players, inProgressGame = null, startingIndexOverride = null)
+
+        assertTrue(
+            "Random starting index must be in range [0, players.size)",
+            vm.startingIndex in 0 until players.size
+        )
+    }
+
     // ── initGame — startingIndex, gameId, displayNames ───────────────────────
 
     @Test

--- a/docs/player-setup.md
+++ b/docs/player-setup.md
@@ -9,17 +9,18 @@ The landing screen lets users configure a game before it starts. It currently ha
 
 ## Layout
 
-The screen uses a scrollable `Column`. The layout order follows the natural user flow — configure players, enter names, then start:
+The screen uses a scrollable `Column`. The layout order follows the natural user flow — configure players, enter names, choose a dealer, then start:
 
 1. Language switcher (flag toggle, top-right)
 2. Card-suit decorative header (`♠ ♥ ♦ ♣`, in primary color)
 3. App title
 4. Player count chips (3 / 4 / 5)
 5. Player name fields
-6. **Start Game button** ← below the name fields
-7. Resume Game card (if an unfinished game is saved)
-8. Past Games list (if any completed games exist)
-9. **Feedback button** ← right-aligned, below Past Games
+6. **First Dealer section** ← new (issue #128)
+7. **Start Game button** ← below the dealer section
+8. Resume Game card (if an unfinished game is saved)
+9. Past Games list (if any completed games exist)
+10. **Feedback button** ← right-aligned, below Past Games
 
 ## Visual design
 
@@ -97,6 +98,46 @@ val hasDuplicates = duplicateFlags.any { it }
 ```
 
 Because `resolvedNames`, `lowerNames`, `duplicateFlags`, and `hasDuplicates` are plain `val`s computed inside the composable, Compose recalculates them automatically on every recomposition (i.e. every keystroke). No `remember` or `LaunchedEffect` is needed.
+
+## First Dealer selection
+
+The "First Dealer" section sits between the player name fields and the Start Game button. It lets the user control who distributes the cards for the very first round.
+
+### Two modes
+
+| Mode | Behavior |
+|---|---|
+| **Random** (default) | The app picks a random player from the list; the choice is invisible to users. |
+| **Choose** | A `SingleChoiceSegmentedButtonRow` with one segment per player appears so the user can tap a name. Defaults to the first player (index 0). |
+
+### State
+
+```kotlin
+var useRandomDealer by remember { mutableStateOf(true) }
+var selectedDealerIndex by remember { mutableIntStateOf(0) }
+```
+
+`selectedDealerIndex` is reset to 0 whenever the player count changes (inside the player-count button `onClick`) to prevent an out-of-range index after the player list shrinks.
+
+### Callback
+
+The `onStartGame` callback now carries a second parameter:
+
+```kotlin
+onStartGame: (names: List<String>, dealerIndex: Int?) -> Unit
+```
+
+`dealerIndex` is `null` when Random mode is active, and the chosen 0-based index when Choose mode is active.
+
+### ViewModel integration
+
+`GameViewModel.initGame()` accepts an optional `startingIndexOverride: Int? = null`. When `inProgressGame == null` (fresh start), it resolves the starting index as:
+
+```
+inProgressGame?.startingIndex ?: startingIndexOverride ?: displayNames.indices.random()
+```
+
+Restoring a saved game always uses the stored index; the override applies only to new games.
 
 ## Feedback button
 


### PR DESCRIPTION
## Summary

- Adds a **First Dealer** section to the player setup screen (between name fields and Start Game)
- Two modes: **Random** (default — preserves existing behaviour) and **Choose** (shows a segmented button per player)
- The chosen index flows through `onStartGame → MainActivity → GameViewModel.initGame()` via a new optional `startingIndexOverride: Int?` parameter
- Resuming a saved game always uses the stored index and ignores the override

## Changes

- `AppStrings.kt` — 3 new strings: `dealerSelectionLabel`, `randomDealer`, `chooseDealer` (EN + FR)
- `LandingScreen.kt` — dealer selection UI; `onStartGame` signature extended to `(List<String>, Int?) -> Unit`
- `GameViewModel.kt` — `initGame()` gains `startingIndexOverride: Int? = null`
- `MainActivity.kt` — passes `dealerIndex` from setup screen to `initGame()`
- `GameViewModelTest.kt` — 3 new unit tests for the override logic
- `LandingScreenTest.kt` — 5 new UI tests for dealer selection; existing callback tests updated for new signature
- `docs/player-setup.md` + `README.md` — updated to describe the new section

## Test plan

- [ ] Unit tests: `./gradlew testDebugUnitTest` → BUILD SUCCESSFUL
- [ ] Mutation score: `./gradlew pitest` → 82% (above 80% gate)
- [ ] Lint: `./gradlew lint` → BUILD SUCCESSFUL
- [ ] Instrumented tests: run `./gradlew connectedAndroidTest` on device/emulator to verify new dealer-selection UI tests pass

Closes #128