### PR TITLE
feat(129): make score table responsive — no horizontal scroll with 4-5 players

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/UiComponentsTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/UiComponentsTest.kt
@@ -412,4 +412,49 @@ class UiComponentsTest {
         composeTestRule.onNodeWithText("+120").assertIsDisplayed()
         composeTestRule.onNodeWithText("+60").assertIsDisplayed()
     }
+
+    // ── Responsive table (issue #129) ─────────────────────────────────────────
+
+    @Test
+    fun scoreTableRow_five_players_all_headers_visible_without_scroll() {
+        // Verifies that a 5-player header row (the worst case for width overflow)
+        // renders all cells as displayed nodes — i.e. no horizontal scrolling is
+        // required to see any column.
+        val players = listOf("Alice", "Bob", "Charlie", "Diana", "Eve")
+        composeTestRule.setContent {
+            TarotCounterTheme {
+                // fillMaxWidth() gives the Row the full screen width, which is
+                // the same constraint it gets inside the real ScoreHistoryScreen.
+                ScoreTableRow(
+                    cells    = listOf("Round") + players,
+                    isHeader = true
+                )
+            }
+        }
+        // Every header label must be reachable without scrolling.
+        composeTestRule.onNodeWithText("Round").assertIsDisplayed()
+        players.forEach { name ->
+            composeTestRule.onNodeWithText(name).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun scoreTableRow_five_players_data_row_all_scores_visible() {
+        // Data row equivalent of the header test — scores for all 5 players must
+        // be simultaneously visible so the user can compare results at a glance.
+        composeTestRule.setContent {
+            TarotCounterTheme {
+                ScoreTableRow(
+                    cells       = listOf("1", "+100", "-25", "+50", "-75", "-50"),
+                    isHeader    = false,
+                    scoreValues = listOf(null, 100, -25, 50, -75, -50)
+                )
+            }
+        }
+        composeTestRule.onNodeWithText("+100").assertIsDisplayed()
+        composeTestRule.onNodeWithText("-25").assertIsDisplayed()
+        composeTestRule.onNodeWithText("+50").assertIsDisplayed()
+        composeTestRule.onNodeWithText("-75").assertIsDisplayed()
+        composeTestRule.onNodeWithText("-50").assertIsDisplayed()
+    }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/FinalScoreScreen.kt
@@ -4,7 +4,6 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.scaleIn
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -19,7 +18,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.EmojiEvents
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.AlertDialog
@@ -237,9 +235,9 @@ fun FinalScoreScreen(
         Spacer(modifier = Modifier.height(12.dp))
 
         // ── Score table ───────────────────────────────────────────────────────
-        // Scrolls horizontally (5 players) and vertically (many rounds).
-        // Winner column(s) receive a `secondaryContainer` tint so they stand out
-        // without competing visually with the winner card above.
+        // The table uses weighted columns (ScoreTableRow) so it always fills the
+        // available width without horizontal scrolling, regardless of player count
+        // (issue #129). Winner column(s) receive a secondaryContainer tint.
         if (roundHistory.isEmpty()) {
             // No rounds were played — show a simple notice instead of an empty table.
             Text(
@@ -248,17 +246,7 @@ fun FinalScoreScreen(
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
         } else {
-            // Box lets us overlay a scroll-hint arrow when the table is wider than
-            // the screen. The Icon anchors to Alignment.TopEnd so it is immediately
-            // visible when the user arrives at this screen and disappears once they
-            // scroll the table to the right.
-            val hScrollState = rememberScrollState()
-            Box {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(hScrollState)
-                ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
                 // Header row: localized "Round" label + one header per player name.
                 // No score values for the header row — labels use the default colour.
                 ScoreTableRow(
@@ -279,20 +267,6 @@ fun FinalScoreScreen(
                     )
                 }
             }   // end Column
-
-                // Arrow hint: visible when the table extends beyond the right screen edge.
-                if (hScrollState.canScrollForward) {
-                    Icon(
-                        imageVector        = Icons.AutoMirrored.Filled.ArrowForward,
-                        contentDescription = null,
-                        tint               = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier           = Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(4.dp)
-                            .size(16.dp)
-                    )
-                }
-            }   // end Box
         }
 
         Spacer(modifier = Modifier.height(32.dp))

--- a/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
@@ -1,6 +1,5 @@
 package fr.mandarine.tarotcounter
 
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -9,13 +8,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -38,7 +33,7 @@ import androidx.compose.ui.unit.dp
  *   |   1   |  +50  | -25  |  -25   |
  *   |   2   |  +20  | -10  |  -10   |
  *
- * The table scrolls horizontally (for 5 players) and vertically (for many rounds).
+ * The table uses weighted columns so all players fit on screen at once (issue #129).
  *
  * @param playerNames  Ordered list of player display names (fallbacks already resolved).
  * @param roundHistory Completed rounds in chronological order, oldest first.
@@ -79,56 +74,30 @@ fun ScoreHistoryScreen(
         Spacer(modifier = Modifier.height(12.dp))
 
         // ── Score table ───────────────────────────────────────────────────────
-        // Two scroll directions: left↔right for many players, up↓down for many rounds.
-        // We use a plain Column (not LazyColumn) inside two nested scroll modifiers,
-        // which is fine for Tarot games (typical: tens of rounds, 3–5 players).
-        //
-        // The Box wrapper lets us overlay a scroll-hint arrow when the table extends
-        // beyond the right edge of the screen. The Icon sits at Alignment.TopEnd so
-        // it is visible when the user first opens the screen and naturally disappears
-        // as they scroll down — exactly when the hint is no longer needed.
-        val hScrollState = rememberScrollState()
-        Box {
-            Column(
-                // Only horizontal scrolling here — vertical scrolling is handled
-                // by the outer Column so the two scroll directions don't conflict.
-                modifier = Modifier.horizontalScroll(hScrollState)
-            ) {
-                // Column headers: localized "Round" header, then one header per player name.
-                // No score values for the header row — labels use the default colour.
+        // The table uses weighted columns (ScoreTableRow) so it always fills the
+        // available screen width without horizontal scrolling, regardless of how
+        // many players are in the game (issue #129).
+        // Vertical scrolling is already handled by the outer Column above.
+        Column(modifier = Modifier.fillMaxWidth()) {
+            // Column headers: localized "Round" header, then one header per player name.
+            // No score values for the header row — labels use the default colour.
+            ScoreTableRow(
+                cells    = listOf(strings.roundColumn) + playerNames,
+                isHeader = true
+            )
+            HorizontalDivider()
+
+            // buildScoreTableData() (GameModels.kt) accumulates the running totals and
+            // formats each cell — the loop that was previously duplicated here is now
+            // shared with FinalScoreScreen (issue #75).
+            for (row in buildScoreTableData(playerNames, roundHistory)) {
                 ScoreTableRow(
-                    cells = listOf(strings.roundColumn) + playerNames,
-                    isHeader = true
-                )
-                HorizontalDivider()
-
-                // buildScoreTableData() (GameModels.kt) accumulates the running totals and
-                // formats each cell — the loop that was previously duplicated here is now
-                // shared with FinalScoreScreen (issue #75).
-                for (row in buildScoreTableData(playerNames, roundHistory)) {
-                    ScoreTableRow(
-                        cells       = row.cells,
-                        isHeader    = false,
-                        scoreValues = row.scoreValues
-                    )
-                }
-        }
-
-            // Arrow hint: floats at the top-right corner of the Box.
-            // Visible when there is more content to the right (i.e. ≥4–5 players).
-            // Automatically disappears when the user scrolls right (canScrollForward = false).
-            if (hScrollState.canScrollForward) {
-                Icon(
-                    imageVector        = Icons.AutoMirrored.Filled.ArrowForward,
-                    contentDescription = null,
-                    tint               = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier           = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(4.dp)
-                        .size(16.dp)
+                    cells       = row.cells,
+                    isHeader    = false,
+                    scoreValues = row.scoreValues
                 )
             }
-        }   // end (inner table) Box
+        }   // end table Column
     }   // end Column
     }   // end (centering) Box
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/UiComponents.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/UiComponents.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.Button
@@ -564,12 +563,17 @@ fun scoreColor(total: Int): Color =
 // to eliminate duplication: any bug fix or visual change now applies everywhere.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// Width for the "Round" / "Manche" column — short, as round numbers are at most two digits.
-internal val SCORE_TABLE_ROUND_COL_WIDTH: Dp = 64.dp
+// Relative weight for the "Round" / "Manche" column.
+// Smaller than a player column because round numbers are at most two digits.
+// Using weight (rather than a fixed dp width) makes the table responsive:
+// all columns together always fill exactly the available screen width, so
+// 4- and 5-player games never require horizontal scrolling (issue #129).
+internal const val SCORE_TABLE_ROUND_COL_WEIGHT: Float = 0.8f
 
-// Width for each player column — wide enough for score strings like "+1000"
-// and player names up to about 8 characters.
-internal val SCORE_TABLE_PLAYER_COL_WIDTH: Dp = 80.dp
+// Relative weight for each player column.
+// All player columns share the same weight, so they are evenly distributed
+// across the remaining width after the round column has taken its share.
+internal const val SCORE_TABLE_PLAYER_COL_WEIGHT: Float = 1f
 
 /**
  * A single horizontal row in a score table.
@@ -577,8 +581,14 @@ internal val SCORE_TABLE_PLAYER_COL_WIDTH: Dp = 80.dp
  * Replaces the near-identical `ScoreTableRow` (ScoreHistoryScreen) and
  * `FinalScoreTableRow` (FinalScoreScreen) that existed before issue #75.
  *
- * The first column (index 0) uses [SCORE_TABLE_ROUND_COL_WIDTH]; all others use
- * [SCORE_TABLE_PLAYER_COL_WIDTH].
+ * Each cell uses [Modifier.weight] so the row always fills the available width,
+ * regardless of how many players are in the game (issue #129).
+ * The first column (index 0) uses [SCORE_TABLE_ROUND_COL_WEIGHT]; all others
+ * use [SCORE_TABLE_PLAYER_COL_WEIGHT].
+ *
+ * Long player names are automatically shrunk via [AutoSizeText] so they never
+ * overflow their cell. All cells in the same row share a [rememberSharedAutoSizeState]
+ * so they all display at the same — smallest-needed — font size.
  *
  * @param cells               Text content for each cell in left-to-right order.
  * @param isHeader            If true, renders all text in bold (header row).
@@ -596,11 +606,20 @@ fun ScoreTableRow(
     scoreValues: List<Int?>? = null,
     winnerColumnIndices: Set<Int> = emptySet()
 ) {
-    Row {
+    // One shared state per row: all AutoSizeText instances in this row will shrink
+    // together so every cell displays at the same font size. Keyed on the cell
+    // contents so a data change (new round added) resets the shared size to maximum.
+    val rowSizeState = rememberSharedAutoSizeState(*cells.toTypedArray())
+
+    // RowScope is the implicit receiver here, so Modifier.weight() is available
+    // inside forEachIndexed without any extra ceremony.
+    Row(modifier = Modifier.fillMaxWidth()) {
         cells.forEachIndexed { index, text ->
-            // First column ("Round") is narrower; all player columns are wider.
-            val cellWidth = if (index == 0) SCORE_TABLE_ROUND_COL_WIDTH
-                            else           SCORE_TABLE_PLAYER_COL_WIDTH
+            // Round column is slightly narrower than player columns (0.8 vs 1.0).
+            // weight() distributes the Row's full width among all children
+            // proportionally, so the table always fits without horizontal scrolling.
+            val colWeight = if (index == 0) SCORE_TABLE_ROUND_COL_WEIGHT
+                            else            SCORE_TABLE_PLAYER_COL_WEIGHT
 
             val isWinnerColumn = index in winnerColumnIndices
 
@@ -625,23 +644,32 @@ fun ScoreTableRow(
 
             Box(
                 modifier = Modifier
-                    .width(cellWidth)
+                    .weight(colWeight)          // proportional width — fills screen
                     .then(bgModifier)
                     .padding(vertical = 8.dp, horizontal = 4.dp),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = text,
-                    // Bold for header rows and for every cell in a winner column.
-                    style = if (isHeader || isWinnerColumn) {
-                        MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
-                    } else {
-                        MaterialTheme.typography.bodyMedium
-                    },
-                    color = textColor,
-                    textAlign = TextAlign.Center,
-                    // Prevent long names from wrapping and making rows uneven.
-                    maxLines = 1
+                // AutoSizeText shrinks the font until the text fits its cell.
+                // The shared state ensures every cell in this row uses the same size,
+                // which keeps the row visually consistent (no cell looks different).
+                // `textAlign = TextAlign.Center` is baked into the style so the text
+                // stays centred after the font is scaled down.
+                val cellStyle = if (isHeader || isWinnerColumn) {
+                    MaterialTheme.typography.bodyMedium.copy(
+                        fontWeight = FontWeight.Bold,
+                        textAlign  = TextAlign.Center,
+                        color      = textColor
+                    )
+                } else {
+                    MaterialTheme.typography.bodyMedium.copy(
+                        textAlign = TextAlign.Center,
+                        color     = textColor
+                    )
+                }
+                AutoSizeText(
+                    text            = text,
+                    style           = cellStyle,
+                    sharedSizeState = rowSizeState
                 )
             }
         }

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -156,7 +156,8 @@ fun ScoreTableRow(
 
 A single horizontal row in a score table. Used by both `ScoreHistoryScreen` and `FinalScoreScreen`.
 
-- **Column widths:** index 0 ("Round") → `SCORE_TABLE_ROUND_COL_WIDTH` (64 dp); all other columns → `SCORE_TABLE_PLAYER_COL_WIDTH` (80 dp).
+- **Column widths:** uses `Modifier.weight()` — index 0 ("Round") gets weight `SCORE_TABLE_ROUND_COL_WEIGHT` (0.8f); all other columns get `SCORE_TABLE_PLAYER_COL_WEIGHT` (1.0f). This distributes the full available width proportionally, so all columns are always visible on screen regardless of player count (no horizontal scrolling needed, even with 5 players).
+- **Text sizing:** each cell uses `AutoSizeText` with a shared size state per row, so long player names shrink gracefully and all cells in a row stay at the same font size.
 - **`isHeader`:** renders all text bold (for the header row).
 - **`scoreValues`:** parallel list of raw integers for semantic colour coding via `scoreColor()`. Pass `null` or include `null` entries to skip colouring for that cell. Index 0 should always be `null` (round-number column has no colour).
 - **`winnerColumnIndices`:** zero-based column indices highlighted with a gold/amber background and bold text. Defaults to `emptySet()` (no highlighting), so `ScoreHistoryScreen` can use this composable without any extra arguments. `FinalScoreScreen` passes the winner column indices.


### PR DESCRIPTION
## Summary

- Replaces fixed-width table columns (`64 dp` / `80 dp`) in `ScoreTableRow` with `Modifier.weight()` so all columns always share the available screen width proportionally — the table always fits, regardless of player count
- Replaces `Text` with `AutoSizeText` (with a per-row `rememberSharedAutoSizeState`) so long player names shrink gracefully while keeping all cells at the same font size
- Removes the now-unnecessary `horizontalScroll` modifier and scroll-hint arrow from `FinalScoreScreen` and `ScoreHistoryScreen`

## Test plan

- [ ] Build and run on a narrow device (360 dp) with 5 players — all column headers visible without scrolling
- [ ] Confirm winner column highlighting still works on `FinalScoreScreen`
- [ ] Confirm score colours (green/red) still applied on both screens
- [ ] Two new Compose UI tests in `UiComponentsTest` verify 5-player rows are fully visible; mutation score ≥ 80 % (currently 82 %)

Closes #129