### PR TITLE
feat(136): add toggle view to history screen, remove game screen round list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ TarotCounter guides players through a game round by round:
 1. **Setup** — choose 3, 4, or 5 players and optionally enter custom names; duplicate names are detected in real time and the Start button is disabled until all names are unique; choose the **first dealer** (random or pick a specific player); a decorative `♠ ♥ ♦ ♣` header above the title sets the card-game tone; tap the **⚙ gear icon** (top-right) to open the Settings page
 2. **Attacker selection + contract** — tap the player who won the bidding to set them as the **attacker** (any player can bid, not just the dealer); then pick their contract; the dealer label shows who is distributing the cards this round; a persistent **bottom action bar** always shows **End Game** (left) and **Skip round** (right) for quick access
 3. **Scoring details** — enter bouts, points scored (0–91), partner (5-player), and any bonuses; a radio button lets you switch between entering the **taker's points** or the **defenders' points** (the app converts automatically using `takerPoints = 91 − defenderPoints`)
-4. **Scoreboard & history** — live cumulative scores per player and a log of all rounds, newest first; each history row shows a colored **●** indicator (green = won, red = lost, grey = skipped) for at-a-glance scanning
-5. **Score history table** — tap the bar-chart icon (left of the header) to see a round-by-round table of cumulative scores for every player
+4. **Compact scoreboard** — after the first round, a persistent card at the top shows each player's running total at a glance
+5. **Score history screen** — tap the bar-chart icon (always visible in the header) to open the history screen; a **segmented toggle** switches between two views: **Table** (cumulative scores per round, one row per player) and **List** (round-by-round detail log, newest first, with a coloured **●** indicator per row: green = won, red = lost, grey = skipped)
 6. **End Game / Final Score** — tap **End Game** in the bottom bar at any point to see the final results: winner card with total score, full round-by-round table (winner's column highlighted in gold/amber), and three action buttons on one line: **Main Menu** (return to the landing screen), **New Game** (go to setup), and **Back to Game** (resume the current game)
 7. **Colour-coded scores** — positive scores appear in green and negative scores in red across all score views (CompactScoreboard, ScoreHistoryScreen, FinalScoreScreen); colours adapt to light/dark theme automatically
 8. **Auto-save & Resume** — the game state is saved after every round; if the app is closed mid-game, a "Resume Game" card appears on the setup screen the next time it is opened
@@ -75,7 +75,7 @@ app/src/main/java/fr/mandarine/tarotcounter/
 ├── GameScreen.kt          # Round management, taker rotation, details form, history, End Game button
 ├── ScreenHeader.kt        # Shared back-arrow header composable
 ├── SettingsScreen.kt      # Settings page: theme, language, feedback
-├── ScoreHistoryScreen.kt  # Round-by-round cumulative score table
+├── ScoreHistoryScreen.kt  # Score history: table view + list view with toggle
 ├── FinalScoreScreen.kt    # End-of-game results: winner card + full score table
 ├── UiComponents.kt        # Shared UI: AppButton, AppOutlinedButton, AppTextButton, AutoSizeText
 └── ui/theme/              # Material 3 theme, colors, typography
@@ -193,7 +193,7 @@ manual retrace instructions, and where to view crash reports in Play Console.
 | `LandingScreenTest.kt` | Setup screen UI: player count chips, name fields, duplicate validation, settings gear icon |
 | `SettingsScreenTest.kt` | Settings page: back navigation, theme toggle, language toggle, feedback button, section labels |
 | `GameScreenTest.kt` | Full game flow: contract selection, details form, history, score history navigation, End Game button |
-| `ScoreHistoryScreenTest.kt` | Score history table: column headers, cumulative totals, back navigation |
+| `ScoreHistoryScreenTest.kt` | Score history screen: table view, list view, toggle, round indicators, back navigation |
 | `FinalScoreScreenTest.kt` | Final score screen: winner card, tie detection, score table, New Game navigation |
 
 ## Project Structure
@@ -235,7 +235,7 @@ More detailed documentation lives in [`docs/`](docs/):
 - [`docs/game-flow.md`](docs/game-flow.md) — complete game mechanics, data models, round history format
 - [`docs/player-setup.md`](docs/player-setup.md) — setup screen behaviour and validation rules
 - [`docs/settings.md`](docs/settings.md) — settings page: theme toggle, language toggle, feedback button, navigation wiring
-- [`docs/score-history.md`](docs/score-history.md) — score history table: layout, navigation, scrolling
+- [`docs/score-history.md`](docs/score-history.md) — score history screen: table view, list view, toggle, navigation
 - [`docs/final-score.md`](docs/final-score.md) — final score screen: winner card, table highlighting, New Game navigation
 - [`docs/game-persistence.md`](docs/game-persistence.md) — how completed games are saved to DataStore and displayed on the setup screen
 - [`docs/score-color.md`](docs/score-color.md) — score colour-coding convention: `scoreColor()` helper, where it is used, winner column

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -330,50 +330,6 @@ class GameScreenTest {
         composeTestRule.onNodeWithContentDescription("History").assertIsDisplayed()
     }
 
-    @Test
-    fun skipped_round_shows_Skipped_in_history() {
-        launchGame()
-        composeTestRule.onNodeWithText("Skip round").performClick()
-        composeTestRule
-            .onNodeWithText("Skipped", substring = true)
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun played_round_shows_contract_and_score_in_history() {
-        launchGame()
-        // Enter 0 explicitly so the history row shows "0 pts".
-        selectContractAndEnterScore(score = "0")
-        composeTestRule.onNodeWithText("Confirm round").performClick()
-        composeTestRule
-            .onNodeWithText("Garde", substring = true)
-            .assertIsDisplayed()
-        composeTestRule
-            .onNodeWithText("0 pts", substring = true)
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun played_round_shows_Lost_in_history_when_taker_did_not_reach_threshold() {
-        // 0 bouts, 10 points → needs 56 to win → Lost.
-        launchGame()
-        selectContractAndEnterScore(score = "10")
-        composeTestRule.onNodeWithText("Confirm round").performClick()
-        composeTestRule
-            .onNodeWithText("Lost", substring = true)
-            .assertIsDisplayed()
-    }
-
-    @Test
-    fun history_is_newest_round_first() {
-        launchGame()
-        composeTestRule.onNodeWithText("Skip round").performClick() // round 1 skipped
-        composeTestRule.onNodeWithText("Skip round").performClick() // round 2 skipped
-
-        composeTestRule.onNodeWithText("Round 1", substring = true).assertIsDisplayed()
-        composeTestRule.onNodeWithText("Round 2", substring = true).assertIsDisplayed()
-    }
-
     // ── Spec: scoreboard shown after a played round ────────────────────────────
 
     @Test
@@ -648,8 +604,8 @@ class GameScreenTest {
 
         composeTestRule.onNodeWithText("Confirm round").performClick()
 
-        // The round must be recorded as won.
-        composeTestRule.onNodeWithTag("round_indicator_won").assertIsDisplayed()
+        // The round was recorded successfully — the header advances to Round 2.
+        composeTestRule.onNodeWithText("Round 2").assertIsDisplayed()
     }
 
     // ── Spec: points field validation (issue #8) ──────────────────────────────
@@ -701,40 +657,6 @@ class GameScreenTest {
         composeTestRule.onNodeWithText("Confirm round").assertIsEnabled()
     }
 
-    // ── Spec: styled round history rows (issue #6) ────────────────────────────
-
-    @Test
-    fun skipped_round_shows_skipped_indicator() {
-        launchGame()
-        composeTestRule.onNodeWithText("Skip round").performClick()
-        composeTestRule.onNodeWithTag("round_indicator_skipped").assertIsDisplayed()
-    }
-
-    @Test
-    fun lost_round_shows_lost_indicator() {
-        launchGame()
-        selectContractAndEnterScore(score = "10") // 10 pts, 0 bouts → Lost
-        composeTestRule.onNodeWithText("Confirm round").performClick()
-        composeTestRule.onNodeWithTag("round_indicator_lost").assertIsDisplayed()
-    }
-
-    @Test
-    fun won_round_shows_won_indicator() {
-        launchGame()
-        // Select an attacker (required since issue #124) before picking the contract.
-        selectAttacker()
-        composeTestRule.onNodeWithText("Garde").performClick()
-
-        composeTestRule.onNodeWithTag("bouts_dropdown").performClick()
-        composeTestRule.onAllNodesWithText("3")[0].performClick()
-
-        composeTestRule.onNodeWithTag("points_input").performTextInput("91")
-
-        composeTestRule.onNodeWithText("Confirm round").performClick()
-
-        composeTestRule.onNodeWithTag("round_indicator_won").assertIsDisplayed()
-    }
-
     // ── Spec: bonus label cell is fully tappable (issue #36) ─────────────────
 
     @Test
@@ -765,17 +687,6 @@ class GameScreenTest {
                     nodes.size >= 1
                 )
             }
-    }
-
-    @Test
-    fun multiple_rounds_show_correct_indicators() {
-        launchGame()
-        composeTestRule.onNodeWithText("Skip round").performClick()  // round 1 → skipped
-        selectContractAndEnterScore(score = "10")                    // round 2 → lost
-        composeTestRule.onNodeWithText("Confirm round").performClick()
-
-        composeTestRule.onNodeWithTag("round_indicator_skipped").assertIsDisplayed()
-        composeTestRule.onNodeWithTag("round_indicator_lost").assertIsDisplayed()
     }
 
     // ── Spec: system back-button on game screen (issue #38) ───────────────────

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/ScoreHistoryScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/ScoreHistoryScreenTest.kt
@@ -3,6 +3,7 @@ package fr.mandarine.tarotcounter
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -247,5 +248,155 @@ class ScoreHistoryScreenTest {
             .onNodeWithContentDescription("Back to game")
             .performClick()
         assertTrue("onBack callback should have been called", backCalled)
+    }
+
+    // ── Spec: view mode toggle ────────────────────────────────────────────────
+
+    @Test
+    fun view_toggle_is_displayed() {
+        // The segmented toggle ("Table" / "List") must appear on the history screen.
+        launchHistory()
+        composeTestRule.onNodeWithTag("history_view_toggle").assertIsDisplayed()
+    }
+
+    @Test
+    fun default_view_is_table() {
+        // On first open the TABLE segment must be selected — shown by the Round column header.
+        launchHistory()
+        composeTestRule.onNodeWithText("Table").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Round").assertIsDisplayed()
+    }
+
+    @Test
+    fun tapping_list_tab_switches_to_list_view() {
+        // After tapping the List segment the "Round" table column header disappears
+        // (because the list view does not use a table header row).
+        val history = listOf(
+            RoundResult(
+                roundNumber = 1, takerName = "Alice",
+                contract = null, details = null, won = null
+            )
+        )
+        launchHistory(roundHistory = history)
+        composeTestRule.onNodeWithTag("toggle_list").performClick()
+        // The round column header is part of the TABLE view only — it must be gone.
+        composeTestRule.onNodeWithText("Round").assertDoesNotExist()
+    }
+
+    @Test
+    fun tapping_table_tab_after_list_restores_table() {
+        // TABLE → LIST → TABLE round-trip: the round column header must reappear.
+        val history = listOf(
+            RoundResult(
+                roundNumber = 1, takerName = "Alice",
+                contract = null, details = null, won = null
+            )
+        )
+        launchHistory(roundHistory = history)
+        composeTestRule.onNodeWithTag("toggle_list").performClick()
+        composeTestRule.onNodeWithTag("toggle_table").performClick()
+        composeTestRule.onNodeWithText("Round").assertIsDisplayed()
+    }
+
+    // ── Spec: LIST view — round indicators (issue #136) ──────────────────────
+
+    /** Helper: launch the history screen in LIST view. */
+    private fun launchHistoryInListMode(roundHistory: List<RoundResult> = emptyList()) {
+        launchHistory(roundHistory = roundHistory)
+        composeTestRule.onNodeWithTag("toggle_list").performClick()
+    }
+
+    @Test
+    fun list_view_empty_state_shows_no_rounds_played() {
+        // Empty history in list view shows the "No rounds played" notice.
+        launchHistoryInListMode()
+        composeTestRule.onNodeWithText("No rounds played").assertIsDisplayed()
+    }
+
+    @Test
+    fun list_view_skipped_round_shows_skipped_indicator() {
+        val history = listOf(
+            RoundResult(
+                roundNumber = 1, takerName = "Alice",
+                contract = null, details = null, won = null
+            )
+        )
+        launchHistoryInListMode(roundHistory = history)
+        composeTestRule.onNodeWithTag("round_indicator_skipped").assertIsDisplayed()
+    }
+
+    @Test
+    fun list_view_won_round_shows_won_indicator() {
+        val history = listOf(
+            RoundResult(
+                roundNumber  = 1, takerName = "Alice",
+                contract     = Contract.GARDE, details = null, won = true,
+                playerScores = mapOf("Alice" to 50, "Bob" to -25, "Charlie" to -25)
+            )
+        )
+        launchHistoryInListMode(roundHistory = history)
+        composeTestRule.onNodeWithTag("round_indicator_won").assertIsDisplayed()
+    }
+
+    @Test
+    fun list_view_lost_round_shows_lost_indicator() {
+        val history = listOf(
+            RoundResult(
+                roundNumber  = 1, takerName = "Alice",
+                contract     = Contract.PRISE, details = null, won = false,
+                playerScores = mapOf("Alice" to -25, "Bob" to 12, "Charlie" to 13)
+            )
+        )
+        launchHistoryInListMode(roundHistory = history)
+        composeTestRule.onNodeWithTag("round_indicator_lost").assertIsDisplayed()
+    }
+
+    @Test
+    fun list_view_shows_skipped_text_for_skipped_round() {
+        val history = listOf(
+            RoundResult(
+                roundNumber = 1, takerName = "Alice",
+                contract = null, details = null, won = null
+            )
+        )
+        launchHistoryInListMode(roundHistory = history)
+        composeTestRule.onNodeWithText("Skipped", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun list_view_shows_multiple_round_indicators() {
+        val history = listOf(
+            RoundResult(
+                roundNumber = 1, takerName = "Alice",
+                contract = null, details = null, won = null
+            ),
+            RoundResult(
+                roundNumber  = 2, takerName = "Bob",
+                contract     = Contract.PRISE, details = null, won = false,
+                playerScores = mapOf("Alice" to 10, "Bob" to -20, "Charlie" to 10)
+            )
+        )
+        launchHistoryInListMode(roundHistory = history)
+        composeTestRule.onNodeWithTag("round_indicator_skipped").assertIsDisplayed()
+        composeTestRule.onNodeWithTag("round_indicator_lost").assertIsDisplayed()
+    }
+
+    @Test
+    fun list_view_is_newest_round_first() {
+        // With two rounds, the most recent round (round 2) must appear in the list.
+        val history = listOf(
+            RoundResult(
+                roundNumber = 1, takerName = "Alice",
+                contract = null, details = null, won = null
+            ),
+            RoundResult(
+                roundNumber = 2, takerName = "Bob",
+                contract = null, details = null, won = null
+            )
+        )
+        launchHistoryInListMode(roundHistory = history)
+        // Both round numbers must be visible (newest first ordering).
+        composeTestRule.onNodeWithText("Round 2", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Round 1", substring = true).assertIsDisplayed()
     }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/AppStrings.kt
@@ -130,6 +130,10 @@ data class AppStrings(
     val scoreHistory: String,
     // "Round" / "Manche" column header in the score table.
     val roundColumn: String,
+    // Labels for the two-mode view toggle on the history screen.
+    // TABLE = the cumulative score table; LIST = the round-by-round detail list.
+    val historyViewTable: String,
+    val historyViewList: String,
 
     // ── Back-navigation confirmation dialog (Final Score screen) ──────────────
     // Shown when the user presses the system back button on the Final Score screen.
@@ -269,6 +273,8 @@ val EnStrings = AppStrings(
 
     scoreHistory          = "Score history",
     roundColumn           = "Round",
+    historyViewTable      = "Table",
+    historyViewList       = "List",
 
     backConfirmTitle      = "Leave the game?",
     backConfirmBody       = "The game results won't be saved if you leave now.",
@@ -385,6 +391,8 @@ val FrStrings = AppStrings(
 
     scoreHistory          = "Historique des scores",
     roundColumn           = "Manche",
+    historyViewTable      = "Tableau",
+    historyViewList       = "Liste",
 
     backConfirmTitle      = "Quitter la partie ?",
     backConfirmBody       = "Les résultats ne seront pas sauvegardés si vous quittez maintenant.",

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -710,24 +710,6 @@ fun GameScreen(
             }
             // end inline round details
 
-            // ── Round history (newest-first) ──────────────────────────────────
-            if (roundHistory.isNotEmpty()) {
-                Spacer(Modifier.height(24.dp))
-                HorizontalDivider()
-                Spacer(Modifier.height(12.dp))
-
-                val reversedHistory = roundHistory.reversed()
-                reversedHistory.forEachIndexed { index, round ->
-                    RoundHistoryRow(round = round, locale = locale, strings = strings)
-                    if (index < reversedHistory.lastIndex) {
-                        HorizontalDivider(
-                            modifier  = Modifier.padding(vertical = 4.dp),
-                            thickness = 0.5.dp,
-                            color     = MaterialTheme.colorScheme.outlineVariant
-                        )
-                    }
-                }
-            }
         }  // end inner scrollable Column
 
         // ── Bottom action bar ─────────────────────────────────────────────────
@@ -906,7 +888,7 @@ fun HistoryButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
 // The `testTag` on the dot lets UI tests assert the correct outcome without
 // reading color values directly.
 @Composable
-private fun RoundHistoryRow(
+internal fun RoundHistoryRow(
     round:   RoundResult,
     locale:  AppLocale,
     strings: AppStrings

--- a/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/ScoreHistoryScreen.kt
@@ -6,34 +6,51 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
+// ── View mode enum ────────────────────────────────────────────────────────────
+
+// Represents the two display modes available on the history screen:
+//   TABLE — the existing cumulative score table (one row per round, one column per player)
+//   LIST  — a round-by-round detail list (previously shown at the bottom of GameScreen)
+enum class HistoryViewMode { TABLE, LIST }
+
+// Returns the localized label for each view mode.
+// Kept private to this file — the enum is shared but the label mapping is a UI detail.
+private fun HistoryViewMode.label(strings: AppStrings) = when (this) {
+    HistoryViewMode.TABLE -> strings.historyViewTable
+    HistoryViewMode.LIST  -> strings.historyViewList
+}
+
 /**
- * ScoreHistoryScreen displays the score evolution as a table.
+ * ScoreHistoryScreen displays the score history in one of two views, switchable via a
+ * segmented toggle at the top of the content area:
+ *
+ *   TABLE (default) — cumulative score table, one row per completed round.
+ *   LIST            — round-by-round detail list that was previously shown at the
+ *                     bottom of the Game screen.
  *
  * Layout:
  *   - Header: back arrow + "Score history" title (localized)
- *   - Table: one row per completed round, one column per player
- *     - Each cell shows the player's **cumulative** total after that round,
- *       matching exactly what the scoreboard shows on the game screen.
- *
- * Example (3 players, 2 completed rounds):
- *
- *   | Round | Alice | Bob  | Charlie |
- *   |-------|-------|------|---------|
- *   |   1   |  +50  | -25  |  -25   |
- *   |   2   |  +20  | -10  |  -10   |
- *
- * The table uses weighted columns so all players fit on screen at once (issue #129).
+ *   - View toggle: segmented button to switch between TABLE and LIST
+ *   - Content: either the score table or the round-detail list
  *
  * @param playerNames  Ordered list of player display names (fallbacks already resolved).
  * @param roundHistory Completed rounds in chronological order, oldest first.
@@ -48,7 +65,12 @@ fun ScoreHistoryScreen(
     modifier: Modifier = Modifier
 ) {
     // Read the active locale and resolve all strings once at the top of the composable.
-    val strings = appStrings(LocalAppLocale.current)
+    val locale  = LocalAppLocale.current
+    val strings = appStrings(locale)
+
+    // Which view is currently active. Defaults to TABLE and resets each time the
+    // screen enters the composition (i.e. every time the user opens the history overlay).
+    var viewMode by remember { mutableStateOf(HistoryViewMode.TABLE) }
 
     // Box centers the content Column horizontally on wide screens (tablets in landscape).
     Box(
@@ -59,46 +81,137 @@ fun ScoreHistoryScreen(
         modifier = Modifier
             .widthIn(max = MAX_CONTENT_WIDTH)
             .fillMaxWidth()
-            // verticalScroll on the outer Column scrolls the entire page (header + table)
-            // vertically, so long game histories never clip off-screen.
+            // verticalScroll scrolls the entire page (header + toggle + content) as one unit.
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp, vertical = 8.dp)
     ) {
         // ── Screen header: back arrow + title ─────────────────────────────────
-        // ScreenHeader is the shared composable defined in ScreenHeader.kt —
-        // it renders a back arrow + title in a Row, consistent with FinalScoreScreen.
         ScreenHeader(title = strings.scoreHistory, onBack = onBack)
 
         Spacer(modifier = Modifier.height(8.dp))
         HorizontalDivider()
         Spacer(modifier = Modifier.height(12.dp))
 
-        // ── Score table ───────────────────────────────────────────────────────
-        // The table uses weighted columns (ScoreTableRow) so it always fills the
-        // available screen width without horizontal scrolling, regardless of how
-        // many players are in the game (issue #129).
-        // Vertical scrolling is already handled by the outer Column above.
-        Column(modifier = Modifier.fillMaxWidth()) {
-            // Column headers: localized "Round" header, then one header per player name.
-            // No score values for the header row — labels use the default colour.
-            ScoreTableRow(
-                cells    = listOf(strings.roundColumn) + playerNames,
-                isHeader = true
-            )
-            HorizontalDivider()
+        // ── View mode toggle ──────────────────────────────────────────────────
+        // SingleChoiceSegmentedButtonRow is the Material 3 standard for mutually
+        // exclusive options. The selected segment is visually filled; no checkmark
+        // icon is shown (icon = {}) because the fill already communicates selection.
+        //
+        // rememberSharedAutoSizeState ensures both labels shrink to the same font
+        // size if either label overflows its half-width slot (e.g. on a small screen
+        // with a long translation). Keyed on locale so a language change resets sizing.
+        val modes     = HistoryViewMode.entries
+        val labelSize = rememberSharedAutoSizeState(locale)
 
-            // buildScoreTableData() (GameModels.kt) accumulates the running totals and
-            // formats each cell — the loop that was previously duplicated here is now
-            // shared with FinalScoreScreen (issue #75).
-            for (row in buildScoreTableData(playerNames, roundHistory)) {
-                ScoreTableRow(
-                    cells       = row.cells,
-                    isHeader    = false,
-                    scoreValues = row.scoreValues
-                )
+        SingleChoiceSegmentedButtonRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("history_view_toggle")
+        ) {
+            modes.forEachIndexed { index, mode ->
+                SegmentedButton(
+                    shape    = SegmentedButtonDefaults.itemShape(index, modes.size),
+                    selected = viewMode == mode,
+                    onClick  = { viewMode = mode },
+                    // Suppress the default checkmark — the filled segment already shows selection.
+                    icon     = {},
+                    modifier = Modifier.testTag("toggle_${mode.name.lowercase()}")
+                ) {
+                    AutoSizeText(
+                        text            = mode.label(strings),
+                        modifier        = Modifier.padding(horizontal = 1.dp),
+                        sharedSizeState = labelSize
+                    )
+                }
             }
-        }   // end table Column
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // ── Content area — switches based on the selected view mode ───────────
+        when (viewMode) {
+            HistoryViewMode.TABLE -> ScoreTableView(
+                playerNames  = playerNames,
+                roundHistory = roundHistory,
+                strings      = strings
+            )
+            HistoryViewMode.LIST -> RoundListView(
+                roundHistory = roundHistory,
+                locale       = locale,
+                strings      = strings
+            )
+        }
     }   // end Column
     }   // end (centering) Box
 }
 
+// ── TABLE view ────────────────────────────────────────────────────────────────
+
+// Renders the cumulative score table: one row per completed round, one column per player.
+// The table uses weighted columns (ScoreTableRow) so it always fills the available width
+// without horizontal scrolling, regardless of player count (issue #129).
+@Composable
+private fun ScoreTableView(
+    playerNames: List<String>,
+    roundHistory: List<RoundResult>,
+    strings: AppStrings
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // Header row: "Round" label + one column per player name.
+        ScoreTableRow(
+            cells    = listOf(strings.roundColumn) + playerNames,
+            isHeader = true
+        )
+        HorizontalDivider()
+
+        // buildScoreTableData() (GameModels.kt) accumulates running totals and formats
+        // each cell — shared with FinalScoreScreen (issue #75).
+        for (row in buildScoreTableData(playerNames, roundHistory)) {
+            ScoreTableRow(
+                cells       = row.cells,
+                isHeader    = false,
+                scoreValues = row.scoreValues
+            )
+        }
+    }
+}
+
+// ── LIST view ─────────────────────────────────────────────────────────────────
+
+// Renders the round-by-round detail list, newest round first.
+// Each row uses RoundHistoryRow (GameScreen.kt) — the same composable that was
+// previously shown at the bottom of the Game screen (removed in issue #136).
+@Composable
+private fun RoundListView(
+    roundHistory: List<RoundResult>,
+    locale: AppLocale,
+    strings: AppStrings
+) {
+    if (roundHistory.isEmpty()) {
+        // No rounds played yet — the list would be empty, so show a brief notice
+        // consistent with how FinalScoreScreen handles the same edge case.
+        androidx.compose.material3.Text(
+            text  = strings.noRoundsPlayed,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        return
+    }
+
+    // Show newest round first so the most recent result is immediately visible
+    // without scrolling — mirrors the ordering that was used in GameScreen.
+    val reversedHistory = roundHistory.reversed()
+    Column(modifier = Modifier.fillMaxWidth()) {
+        reversedHistory.forEachIndexed { index, round ->
+            RoundHistoryRow(round = round, locale = locale, strings = strings)
+            // Thin divider between rows; omitted after the last one.
+            if (index < reversedHistory.lastIndex) {
+                HorizontalDivider(
+                    modifier  = Modifier.padding(vertical = 4.dp),
+                    thickness = 0.5.dp,
+                    color     = MaterialTheme.colorScheme.outlineVariant
+                )
+            }
+        }
+    }
+}

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -179,23 +179,11 @@ The partner (5-player) does not participate in the poignée bonus exchange. The 
 
 The minimum number of trumps needed to declare each type differs per player count — see the [Poignée thresholds table](#poignée-trump-thresholds) in the Inline round details section above.
 
-## Compact Scoreboard & Round History
+## Compact Scoreboard
 
 After the first round is completed the game screen shows a persistent **compact scoreboard** at the top of the page — one column per player with their name and running total. This stays visible at all times without opening a separate screen.
 
 Each player column carries `Modifier.weight(1f)` so all columns share the card width equally. Player names that are too long for their column are truncated with an ellipsis ("…") rather than overflowing their neighbours — this is important in 5-player games on narrow screens.
-
-Below the round input, a full round-by-round log is displayed newest-first.
-Each row begins with a colored **●** indicator so the outcome is readable at a glance
-without reading the text:
-
-| Indicator color | Outcome  |
-|-----------------|----------|
-| Green (primary) | Won      |
-| Red (error)     | Lost     |
-| Grey (muted)    | Skipped  |
-
-All indicator colors are Material theme tokens, adapting automatically to light and dark mode.
 
 ```
 Scores
@@ -203,16 +191,9 @@ Scores
 │ Alice   Bob    Charlie  │
 │  +80    -40     -40     │
 └─────────────────────────┘
-
-●  Round 2: Bob — Prise · 0 bouts · 50 pts — Lost (-31)
-●  Round 1: Alice — Garde · 2 bouts · 56 pts — Won (+80)
 ```
 
-Skipped rounds show no outcome and do not affect scores.
-
-The `RoundHistoryRow` composable (private to `GameScreen.kt`) handles this layout.
-It receives a `RoundResult`, builds the text content, and renders the indicator + text in a `Row`.
-A thin `HorizontalDivider` (0.5 dp) separates consecutive rows for better readability.
+The full round-by-round detail log is available on the **Score History screen** (opened via the bar-chart icon in the header) in **List view** — see `docs/score-history.md`.
 
 #### Header
 

--- a/docs/score-history.md
+++ b/docs/score-history.md
@@ -2,13 +2,20 @@
 
 ## Purpose
 
-The score history screen shows the **evolution of cumulative scores** across all completed rounds in a single table view. It is accessed from the game screen once at least one round has been recorded.
+The score history screen shows the full history of a game in one of two display modes:
+
+- **Table view** (default) — cumulative score table, one row per completed round.
+- **List view** — round-by-round detail list, newest round first (previously shown at the bottom of the game screen).
+
+Users can switch between the two modes at any time using the segmented toggle at the top of the screen.
 
 ## How to Access
 
-A bar-chart icon button (⬛) appears to the right of the "Scores" heading on the game screen after the first round completes. Tapping it opens the score history table. Tapping the back arrow returns to the game without losing any state.
+A bar-chart icon button (⬛) is always visible in the top-left corner of the game screen. Tapping it opens the score history screen. Tapping the back arrow returns to the game without losing any state.
 
-## Table Layout
+## View Modes
+
+### Table view (default)
 
 ```
 | Round | Alice | Bob  | Charlie |
@@ -20,15 +27,40 @@ A bar-chart icon button (⬛) appears to the right of the "Scores" heading on th
 
 - **Rows** — one per completed round, oldest first (top = round 1).
 - **Columns** — one per player, in setup order, plus a "Round" column on the left.
-- **Cell values** — the player's **running total** after that round (not the per-round delta). Positive values are prefixed with `+` for quick readability. Positive scores appear in green (`primary`) and negative scores in red (`error`) — see `ScoreColor.kt`.
-- **Skipped rounds** — appear as a row where all scores are unchanged from the previous row (since skipped rounds contribute 0 points to everyone).
+- **Cell values** — the player's **running total** after that round (not the per-round delta). Positive values are prefixed with `+`. Positive scores appear in green (`primary`) and negative in red (`error`) — see `ScoreColor.kt`.
+- **Skipped rounds** — appear as rows where all scores are unchanged from the previous row.
+
+### List view
+
+```
+●  Round 2: Bob — Prise · 0 bouts · 50 pts — Lost (-31)
+●  Round 1: Alice — Garde · 2 bouts · 56 pts — Won (+80)
+```
+
+Rounds are displayed **newest first**. Each row begins with a coloured **●** indicator:
+
+| Colour       | Outcome |
+|--------------|---------|
+| Green (primary) | Won  |
+| Red (error)  | Lost    |
+| Grey (muted) | Skipped |
+
+The `RoundHistoryRow` composable (in `GameScreen.kt`) handles this layout — it was moved here from the bottom of the game screen as part of issue #136.
+
+## Toggle
+
+The view toggle is a `SingleChoiceSegmentedButtonRow` with two segments:
+
+| Segment label (EN) | Segment label (FR) | View shown |
+|--------------------|--------------------|------------|
+| Table              | Tableau            | Cumulative score table |
+| List               | Liste              | Round-by-round detail list |
+
+The toggle defaults to **Table** every time the screen is opened (state is not persisted across sessions).
 
 ## Scrolling
 
-- **Horizontal scroll** — for 5-player games where the table is wider than the screen (applied to the inner table Column).
-- **Vertical scroll** — for long games with many rounds (applied to the outer Column so the full page, including the header, scrolls together).
-
-The two scroll directions are intentionally separated: the outer Column owns vertical scrolling, and the inner table Column owns horizontal scrolling. This prevents scroll gesture conflicts.
+Both views scroll vertically as part of the outer `Column`. For table view specifically, all columns share the available width equally via `weight(1f)` so there is no horizontal scroll (issue #129).
 
 ## Navigation
 


### PR DESCRIPTION
## Summary

- **Remove** the round-history list from the bottom of `GameScreen` — the compact scoreboard at the top is sufficient and the list was redundant
- **Add** a TABLE / LIST segmented toggle to `ScoreHistoryScreen`:
  - **Table** (default) — existing cumulative score table, unchanged
  - **List** — round-by-round detail log (moved from GameScreen), newest first, with colour-coded ● indicators (green = won, red = lost, grey = skipped)
- `RoundHistoryRow` promoted from `private` to `internal` so `ScoreHistoryScreen` can reuse it
- New strings `historyViewTable` / `historyViewList` added in EN (`"Table"` / `"List"`) and FR (`"Tableau"` / `"Liste"`)

## Test plan

- [ ] `./gradlew testDebugUnitTest` — passes (24 unit tests)
- [ ] `./gradlew pitest` — 82% mutation score (above 80% gate)
- [ ] `./gradlew lint` — no new warnings
- [ ] Manual: open history screen → default shows Table view with score table
- [ ] Manual: tap "List" segment → shows round-by-round detail list, newest first
- [ ] Manual: tap "Table" segment → returns to score table
- [ ] Manual: GameScreen bottom no longer shows round history rows
- [ ] Manual: both EN and FR locales display correct toggle labels

Closes #136