### PR TITLE
fix(145): align Points label with Nombre de bouts in game screen

### DIFF
--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -378,16 +379,30 @@ fun GameScreen(
 
                 // ── Bouts + Points side by side ───────────────────────────────
                 // Placing these in a Row cuts vertical space compared to stacking them.
-                // Alignment.Bottom keeps the dropdown and text field on the same baseline.
+                //
+                // IntrinsicSize.Min sets the Row's height to the tallest column's natural
+                // height (i.e. the height of its content without any expansion). This is
+                // needed so fillMaxHeight() inside each Column has a concrete ceiling to
+                // fill up to.
+                //
+                // Both Columns use fillMaxHeight() so they stretch to that shared height.
+                // A weight(1f) Spacer between the label and the field then pushes the
+                // field to the bottom of each Column, keeping both fields vertically
+                // aligned even when one label wraps to more lines than the other
+                // (e.g. "Nombre de bouts (oudlers)" in French wraps but "Points" does not).
                 Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    verticalAlignment = Alignment.Bottom
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(IntrinsicSize.Min),  // height = tallest column's natural height
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    // No verticalAlignment — each Column manages alignment internally
                 ) {
                     // Left half: bouts dropdown (ExposedDropdownMenuBox)
-                    Column(modifier = Modifier.weight(1f)) {
+                    Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
                         FormLabel(strings.numberOfBouts)
-                        Spacer(Modifier.height(8.dp))
+                        // Flexible spacer: grows to fill remaining Column height,
+                        // pushing the dropdown flush with the bottom of the Row.
+                        Spacer(Modifier.weight(1f))
 
                         var boutsExpanded by remember { mutableStateOf(false) }
 
@@ -429,11 +444,13 @@ fun GameScreen(
                     }
 
                     // Right half: points entry with an inline camp toggle
-                    Column(modifier = Modifier.weight(1f)) {
+                    Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
                         // Section header mirrors the "Number of bouts (oudlers)" label
                         // on the left so both halves of the Row look structurally identical.
                         FormLabel(strings.pointsHeader)
-                        Spacer(Modifier.height(8.dp))
+                        // Flexible spacer (mirrors the one in the left Column) so the
+                        // text field always aligns with the bouts dropdown below.
+                        Spacer(Modifier.weight(1f))
                         // ── Points field with trailing camp toggle ───────────────
                         // The floating label tells the user which camp's points to enter.
                         // The trailing icon (person = attacker, group = defenders) lets

--- a/docs/ui-components.md
+++ b/docs/ui-components.md
@@ -197,6 +197,41 @@ A small bold label placed above a form section (e.g. above the bouts dropdown or
 FormLabel(strings.numberOfBouts)
 ```
 
+### Side-by-side form fields with aligned labels and inputs (IntrinsicSize pattern)
+
+When two form fields are placed in a `Row` side by side, both their **labels** and their **input controls** need to align vertically — even when one label is longer than the other (e.g. "Nombre de bouts (oudlers)" wraps to two lines in French while "Points" is always one line).
+
+Using `verticalAlignment = Alignment.Bottom` on the Row aligns the form fields but pushes the shorter column down, misaligning its label (issue #145). The correct pattern is:
+
+```kotlin
+Row(
+    modifier = Modifier
+        .fillMaxWidth()
+        // Row height = tallest column's natural (non-expanded) height.
+        // Required so fillMaxHeight() inside each Column has a concrete ceiling.
+        .height(IntrinsicSize.Min),
+    horizontalArrangement = Arrangement.spacedBy(16.dp)
+    // No verticalAlignment — each Column handles its own vertical layout.
+) {
+    Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
+        FormLabel(strings.numberOfBouts)  // label at top
+        Spacer(Modifier.weight(1f))       // pushes the field to the bottom
+        // … form field (e.g. dropdown)
+    }
+    Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
+        FormLabel(strings.pointsHeader)   // label at top — vertically aligned with the left label
+        Spacer(Modifier.weight(1f))       // pushes the field to the bottom
+        // … form field (e.g. OutlinedTextField)
+    }
+}
+```
+
+Key points:
+- `Modifier.height(IntrinsicSize.Min)` gives the Row a fixed height equal to the tallest column's content height (before any expansion). This is what makes `fillMaxHeight()` inside children meaningful.
+- `fillMaxHeight()` on each Column makes it expand to that shared height.
+- `Spacer(Modifier.weight(1f))` inside each Column acts as a flexible gap — it takes whatever vertical space remains after the label, pushing the form control to the bottom of the Column.
+- Result: labels are top-aligned, form controls are bottom-aligned, regardless of how much each label wraps.
+
 ---
 
 ## BonusInfoIcon


### PR DESCRIPTION
## Summary

- The Bouts/Points side-by-side `Row` used `verticalAlignment = Alignment.Bottom`, which bottom-aligns both child columns. When the French label "Nombre de bouts (oudlers)" wraps to two lines the right (Points) column was shorter and got pushed down, making the "Points" label appear lower than the bouts label.
- Fixed by using `Modifier.height(IntrinsicSize.Min)` on the Row + `Modifier.fillMaxHeight()` on each Column + a `Spacer(Modifier.weight(1f))` between the label and the form field. Both labels now sit at the top (aligned) and both form controls at the bottom (aligned), regardless of label wrapping.
- Documented the `IntrinsicSize.Min` side-by-side field pattern in `docs/ui-components.md`.

## Test plan

- [x] `./gradlew assembleDebug` — builds cleanly
- [x] `./gradlew testDebugUnitTest` — all unit tests pass
- [x] `./gradlew lint` — no new warnings
- [x] `./gradlew pitest` — mutation score 82 % (above 80 % gate)

Closes #145