### PR TITLE
feat(150): confirm game end when points are being entered

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -1184,4 +1184,44 @@ class GameScreenTest {
         // Game should have ended — Final Score screen must now be displayed.
         composeTestRule.onNodeWithText("Game Over").assertIsDisplayed()
     }
+
+    @Test
+    fun end_game_confirmation_dialog_confirm_with_zero_rounds_cancels_game_and_navigates_away() {
+        // Spec (issue #150): if the user typed points but never confirmed a round,
+        // confirming the end-game dialog must cancel the game (not show Final Score).
+        // This covers the zero-rounds path inside the dialog's confirm handler.
+        var endGameCalled = false
+        val storage = FakeGameStorage()
+        val viewModel = GameViewModel(
+            ApplicationProvider.getApplicationContext<Application>(),
+            storage
+        )
+        viewModel.initGame(players, inProgressGame = null)
+        composeTestRule.setContent {
+            TarotCounterTheme {
+                GameScreen(
+                    viewModel = viewModel,
+                    onEndGame = { endGameCalled = true }
+                )
+            }
+        }
+
+        // Enter points (and select attacker + contract) without confirming the round.
+        selectContractAndEnterScore()
+
+        // Trigger the dialog and confirm.
+        composeTestRule.onNodeWithText("End Game").performClick()
+        composeTestRule.onNodeWithText("End the game?").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("End Game").get(1).performClick()
+
+        // onEndGame callback must have fired — user navigates away.
+        assertTrue("Confirming end-game dialog with zero rounds must fire onEndGame", endGameCalled)
+        // Final Score screen must NOT appear.
+        composeTestRule.onNodeWithText("Game Over").assertDoesNotExist()
+        // In-progress game entry must have been cleared from storage.
+        assertTrue(
+            "In-progress game must be cleared when game is cancelled via dialog",
+            storage.clearInProgressCallCount >= 1
+        )
+    }
 }

--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/GameScreenTest.kt
@@ -1080,4 +1080,108 @@ class GameScreenTest {
             )
         }
     }
+
+    // ── Spec: End Game confirmation when points are pending (issue #150) ──────
+    // Clicking "End Game" while the points field is non-empty must show a
+    // confirmation dialog to prevent accidentally discarding unsaved round data.
+
+    @Test
+    fun end_game_without_pending_points_proceeds_without_dialog() {
+        // Spec (issue #150): if the user has NOT typed anything in the points field,
+        // pressing "End Game" should end the game immediately with no dialog.
+        // This ensures normal flow is unaffected when no data would be lost.
+        val viewModel = GameViewModel(
+            ApplicationProvider.getApplicationContext<Application>(),
+            FakeGameStorage()
+        )
+        viewModel.initGame(players, inProgressGame = null)
+        composeTestRule.setContent {
+            TarotCounterTheme {
+                GameScreen(viewModel = viewModel)
+            }
+        }
+
+        // Click "End Game" without touching the points field at all.
+        composeTestRule.onNodeWithText("End Game").performClick()
+
+        // No confirmation dialog should appear — the title is absent.
+        composeTestRule.onNodeWithText("End the game?").assertDoesNotExist()
+    }
+
+    @Test
+    fun end_game_with_pending_points_shows_confirmation_dialog() {
+        // Spec (issue #150): if the user has typed points but not confirmed the round,
+        // pressing "End Game" must show a confirmation dialog so they can cancel.
+        launchGame()
+
+        // Select attacker + contract + type points (but do NOT confirm the round).
+        selectContractAndEnterScore()
+
+        // Click "End Game" while the points field is non-empty.
+        composeTestRule.onNodeWithText("End Game").performClick()
+
+        // The confirmation dialog title must be visible.
+        composeTestRule.onNodeWithText("End the game?").assertIsDisplayed()
+        // The dialog body must also be shown.
+        composeTestRule.onNodeWithText("The current round will not be saved.").assertIsDisplayed()
+    }
+
+    @Test
+    fun end_game_confirmation_dialog_cancel_dismisses_dialog_and_keeps_game_running() {
+        // Spec (issue #150): tapping "Cancel" in the end-game confirmation dialog must
+        // close the dialog and leave the user on the game screen (game still running).
+        launchGame()
+        selectContractAndEnterScore()
+
+        // Trigger the dialog.
+        composeTestRule.onNodeWithText("End Game").performClick()
+        composeTestRule.onNodeWithText("End the game?").assertIsDisplayed()
+
+        // Cancel — the dialog should disappear and the game screen should still be shown.
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        // Dialog is gone.
+        composeTestRule.onNodeWithText("End the game?").assertDoesNotExist()
+        // Game screen is still active — the round header should still be visible.
+        composeTestRule.onNodeWithText("Round 1").assertIsDisplayed()
+        // Final Score screen must NOT have been shown.
+        composeTestRule.onNodeWithText("Game Over").assertDoesNotExist()
+    }
+
+    @Test
+    fun end_game_confirmation_dialog_confirm_ends_game_and_shows_final_score() {
+        // Spec (issue #150): tapping the "End Game" confirm button in the dialog must
+        // end the game and navigate to the Final Score screen (when rounds have been played).
+        val viewModel = GameViewModel(
+            ApplicationProvider.getApplicationContext<Application>(),
+            FakeGameStorage()
+        )
+        viewModel.initGame(players, inProgressGame = null)
+        composeTestRule.setContent {
+            TarotCounterTheme {
+                GameScreen(viewModel = viewModel)
+            }
+        }
+
+        // Confirm one round so roundHistory is non-empty, then start filling the next.
+        selectContractAndEnterScore()
+        composeTestRule.onNodeWithText("Confirm round").performClick()
+
+        // Begin filling the next round (attacker + contract + points) without confirming.
+        selectContractAndEnterScore()
+
+        // Trigger the confirmation dialog and confirm.
+        composeTestRule.onNodeWithText("End Game").performClick()
+        composeTestRule.onNodeWithText("End the game?").assertIsDisplayed()
+        // The dialog has two buttons that say "End Game" — click the one inside the dialog.
+        // onAllNodesWithText gives us both; the last one is the confirm button in the dialog.
+        composeTestRule.onAllNodesWithText("End Game").apply {
+            // There are two: the bottom-bar button and the dialog confirm button.
+            // Index 1 is the dialog button (rendered on top of the game screen).
+            get(1).performClick()
+        }
+
+        // Game should have ended — Final Score screen must now be displayed.
+        composeTestRule.onNodeWithText("Game Over").assertIsDisplayed()
+    }
 }

--- a/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/GameScreen.kt
@@ -111,6 +111,11 @@ fun GameScreen(
     // Controls whether the "undo previous round" confirmation dialog is visible.
     var showUndoConfirm by remember { mutableStateOf(false) }
 
+    // Controls whether the "end game with pending points" confirmation dialog is visible.
+    // This is shown when the user taps "End Game" while the points field is non-empty,
+    // to protect against accidentally discarding unsaved round data.
+    var showEndGameConfirm by remember { mutableStateOf(false) }
+
     // ── Hoisted form state ────────────────────────────────────────────────────
     // These variables are declared here (rather than inside the form block) so
     // the pinned bottom-bar Confirm button can read and submit them without
@@ -306,6 +311,38 @@ fun GameScreen(
             },
             dismissButton = {
                 AppTextButton(text = strings.cancel, onClick = { showUndoConfirm = false })
+            }
+        )
+    }
+
+    // ── End-game confirmation dialog ─────────────────────────────────────────
+    // Shown only when the user taps "End Game" while there are pending points in the
+    // points field, so they cannot accidentally lose unsaved round data.
+    // On confirm: the game ends normally (or is cancelled if no rounds have been played).
+    // On dismiss: the dialog closes and the user continues entering points.
+    if (showEndGameConfirm) {
+        AlertDialog(
+            onDismissRequest = { showEndGameConfirm = false },
+            title = { Text(strings.endGameConfirmTitle) },
+            text  = { Text(strings.endGameConfirmBody) },
+            confirmButton = {
+                AppTextButton(
+                    text    = strings.endGame,
+                    onClick = {
+                        showEndGameConfirm = false
+                        if (roundHistory.isEmpty()) {
+                            // Zero rounds played — cancel the game silently.
+                            viewModel.clearInProgressGame()
+                            onEndGame()
+                        } else {
+                            viewModel.endGame()
+                            showFinalScore = true
+                        }
+                    }
+                )
+            },
+            dismissButton = {
+                AppTextButton(text = strings.cancel, onClick = { showEndGameConfirm = false })
             }
         )
     }
@@ -880,7 +917,12 @@ fun GameScreen(
             AppButton(
                 text     = strings.endGame,
                 onClick  = {
-                    if (roundHistory.isEmpty()) {
+                    // If the user has already typed something in the points field,
+                    // they may be mid-entry — show a confirmation dialog first so
+                    // they cannot accidentally lose unsaved round data (issue #150).
+                    if (pointsText.isNotBlank()) {
+                        showEndGameConfirm = true
+                    } else if (roundHistory.isEmpty()) {
                         // Zero rounds played — cancel silently, nothing to record.
                         viewModel.clearInProgressGame()
                         onEndGame()

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -213,7 +213,7 @@ A persistent three-button bar at the bottom of the screen, always visible regard
 
 | Button | Style | Behaviour |
 |--------|-------|-----------|
-| **End Game** | Filled — error container (red) | Ends the current game. **If at least one round has been played**, the game is saved and the Final Score screen is shown. **If no rounds have been played**, the game is cancelled silently — the in-progress entry is cleared and the user returns to the setup screen without anything being recorded (issue #90). The red color signals that this action terminates the game. |
+| **End Game** | Filled — error container (red) | Ends the current game. **If the points field is non-empty** (pending points entered but not yet confirmed), a confirmation dialog appears first so the user can cancel and continue entering data (issue #150). Once confirmed (or if the field was empty): **if at least one round has been played**, the game is saved and the Final Score screen is shown; **if no rounds have been played**, the game is cancelled silently — the in-progress entry is cleared and the user returns to the setup screen (issue #90). The red color signals that this action terminates the game. |
 | **Skip round** | Outlined | Records the current round as skipped (no contract, no score) and advances to the next one. The outlined style marks it as a secondary/neutral action. |
 | **Confirm round** | Filled — primary | Saves the contract, score, and all bonus details, then advances to the next round. **Disabled** until both a contract is selected *and* a non-empty score is entered. Also disabled while the points field contains an invalid value (> 91). |
 


### PR DESCRIPTION
## Summary

- When the user taps **End Game** while the points field is non-empty (pending points entered but round not yet confirmed), a confirmation dialog is now shown
- The dialog lets the user **Cancel** (return to entering points) or **End Game** (proceed as before)
- When the points field is empty the existing behaviour is unchanged — no dialog, game ends immediately

## Test plan

- [ ] New Compose UI tests in `GameScreenTest.kt` cover all four cases:
  - End Game without pending points → no dialog shown
  - End Game with pending points → confirmation dialog appears
  - Cancel in dialog → dialog dismissed, game continues
  - Confirm in dialog → game ends, Final Score screen shown
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] `./gradlew lint` passes
- [ ] Run on device/emulator: verify dialog appears when you type a score and tap End Game, and that cancelling returns you to the form

Closes #150