### PR TITLE
feat(161): use OutlinedIconButton for settings button on landing page

### DIFF
--- a/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
+++ b/app/src/androidTest/java/fr/mandarine/tarotcounter/LandingScreenTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import fr.mandarine.tarotcounter.ui.theme.TarotCounterTheme
 import org.junit.Assert.assertEquals
@@ -106,6 +107,24 @@ class LandingScreenTest {
         composeTestRule.onNodeWithContentDescription("Settings").performClick()
 
         assert(called) { "Expected onNavigateToSettings to be called when gear icon is tapped" }
+    }
+
+    // ── Spec: settings button is large/consistent with other action buttons ────
+    // The settings button uses OutlinedIconButton (same as HistoryButton in GameScreen)
+    // which renders with a visible border and a minimum 40 dp touch target (issue #161).
+    @Test
+    fun settings_button_has_minimum_touch_target_size() {
+        launch()
+        val bounds = composeTestRule
+            .onNodeWithContentDescription("Settings")
+            .getBoundsInRoot()
+        val width  = bounds.right - bounds.left
+        val height = bounds.bottom - bounds.top
+        // OutlinedIconButton provides at least a 40 dp touch area.
+        assert(width >= 40.dp && height >= 40.dp) {
+            "Expected settings button to be at least 40×40 dp " +
+                "(actual: ${width}×${height})"
+        }
     }
 
     // ── Spec: player-count chips 3, 4, 5 ─────────────────────────────────────

--- a/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
+++ b/app/src/main/java/fr/mandarine/tarotcounter/LandingScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SegmentedButton
@@ -129,9 +129,11 @@ fun LandingScreen(
             horizontalArrangement = Arrangement.End, // push the icon to the right edge
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // IconButton provides the standard 48 dp touch target around the icon.
-            // contentDescription is read aloud by screen-readers (accessibility).
-            IconButton(onClick = onNavigateToSettings) {
+            // OutlinedIconButton provides a visible border around the icon, matching
+            // the HistoryButton and UndoPreviousRoundButton style used in GameScreen.
+            // The outline makes the button visually consistent with other major action
+            // buttons throughout the app, while still providing the standard 48 dp touch target.
+            OutlinedIconButton(onClick = onNavigateToSettings) {
                 Icon(
                     imageVector        = Icons.Default.Settings,
                     contentDescription = strings.settings,


### PR DESCRIPTION
## Summary
- Replace `IconButton` with `OutlinedIconButton` for the settings gear on the landing screen
- Matches the styling of `HistoryButton` and `UndoPreviousRoundButton` in `GameScreen` (same outlined border, same 40 dp minimum touch target)
- Add a UI test verifying the settings button meets the 40 dp minimum size requirement

## Test plan
- [ ] Run `./gradlew connectedAndroidTest` — existing + new `LandingScreenTest` cases pass
- [ ] Visually verify the settings button on the landing page now shows a border consistent with the history button in the game screen

Closes #161